### PR TITLE
Handle duplicate dom

### DIFF
--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -36,31 +36,30 @@ defmodule Premailex.HTMLInlineStyles do
   defp add_rule_set_to_html(%{selector: selector, rules: rules, specificity: specificity}, html) do
     html
     |> Floki.find(selector)
-    |> Enum.reduce(html, &update_style_for_element(&2, &1, rules, specificity))
+    |> Enum.reduce(html, &update_style_for_html(&2, &1, rules, specificity))
   end
 
-  defp update_style_for_element(html, needle, rules, specificity) do
-    Util.traverse(html, needle, fn {name, attrs, children} ->
-      style = attrs
-              |> Enum.into(%{})
-              |> Map.get("style", nil)
-              |> set_inline_style_specificity()
-              |> add_styles_with_specificity(rules, specificity)
+  defp update_style_for_html(html, needle, rules, specificity) do
+    Util.traverse(html, needle, &update_style_for_element(&1, rules, specificity))
+  end
 
-      attrs = attrs
-              |> Enum.filter(fn {name, _} -> name != "style" end)
-              |> Enum.concat([{"style", style}])
+  defp update_style_for_element({name, attrs, children}, rules, specificity) do
+    style = attrs
+            |> Enum.into(%{})
+            |> Map.get("style", nil)
+            |> set_inline_style_specificity()
+            |> add_styles_with_specificity(rules, specificity)
 
-      {name, attrs, children}
-    end)
+    attrs = attrs
+            |> Enum.filter(fn {name, _} -> name != "style" end)
+            |> Enum.concat([{"style", style}])
+
+    {name, attrs, children}
   end
 
   defp set_inline_style_specificity(nil), do: ""
-  defp set_inline_style_specificity(style) do
-    if String.starts_with?(style, "[SPEC="),
-      do: style,
-      else: "[SPEC=1000[#{style}]]"
-  end
+  defp set_inline_style_specificity("[SPEC=" <> _rest = style), do: style
+  defp set_inline_style_specificity(style), do: "[SPEC=1000[#{style}]]"
 
   defp add_styles_with_specificity(style, rules, specificity) do
     "#{style}[SPEC=#{specificity}[#{CSSParser.to_string(rules)}]]"
@@ -69,11 +68,13 @@ defmodule Premailex.HTMLInlineStyles do
   defp normalize_style(html) do
     html
     |> Floki.find("[style]")
-    |> Enum.reduce(html, &merge_style(&2, &1))
+    |> Enum.reduce(html, &merge_styles(&2, &1))
   end
 
-  defp merge_style(html, needle),
-    do: Util.traverse_until_first(html, needle, &merge_style/1)
+  defp merge_styles(html, needle) do
+    Util.traverse_until_first(html, needle, &merge_style/1)
+  end
+
   defp merge_style({name, attrs, children}) do
     style = ~r/\[SPEC\=([\d]+)\[(.[^\]\]]*)\]\]/
             |> Regex.scan(attrs |> Enum.into(%{}) |> Map.get("style"))

--- a/lib/premailex/util.ex
+++ b/lib/premailex/util.ex
@@ -1,17 +1,44 @@
 defmodule Premailex.Util do
-  @moduledoc false
+  @moduledoc """
+  Module that contains utility functions.
+  """
 
+  @type html_tree :: tuple | list
+  @type needle :: binary | tuple | list
+
+  @doc """
+  Traverses tree searching for needle, and will call provided function on
+  any occurances.
+
+  If the function returns {:halt, any}, traverse will stop, and result will
+  be {:halt, html_tree}.
+
+  ## Examples
+
+      iex> Premailex.Util.traverse({"div", [], [{"p", [], ["First paragraph"]}, {"p", [], ["Second paragraph"]}]}, "p", fn {name, attrs, _children} -> {name, attrs, ["Updated"]} end)
+      {"div", [], [{"p", [], ["Updated"]}, {"p", [], ["Updated"]}]}
+
+      iex> Premailex.Util.traverse({"div", [], [{"p", [], ["First paragraph"]}, {"p", [], ["Second paragraph"]}]}, {"p", [], ["Second paragraph"]}, fn {name, attrs, _children} -> {name, attrs, ["Updated"]} end)
+      {"div", [], [{"p", [], ["First paragraph"]}, {"p", [], ["Updated"]}]}
+  """
+  @spec traverse(html_tree, needle, function) :: html_tree | {:halt, html_tree}
   def traverse(html, needles, fun) when is_list(needles),
     do: Enum.reduce(needles, html, &traverse(&2, &1, fun))
-  def traverse(children, needle, fun) when is_list(children),
-    do: Enum.map(children, &traverse(&1, needle, fun))
+  def traverse(children, needle, fun) when is_list(children) do
+    children
+    |> Enum.map_reduce(:ok, &maybe_traverse({&1, needle, fun}, &2))
+    |> case do
+        {children, :halt} -> {:halt, children}
+        {children, :ok}   -> children
+      end
+  end
   def traverse(text, _, _) when is_binary(text),
     do: text
   def traverse({name, attrs, children} = element, needle, fun) do
     cond do
       needle == name    -> fun.(element)
       needle == element -> fun.(element)
-      true              -> {name, attrs, traverse(children, needle, fun)}
+      true              -> handle_traversed({name, attrs, children}, needle, fun)
     end
   end
   def traverse({:comment, _}, _, _),
@@ -19,6 +46,48 @@ defmodule Premailex.Util do
   def traverse(element, _, _),
     do: element
 
+  defp maybe_traverse({element, needle, fun}, :ok) do
+    case traverse(element, needle, fun) do
+      {:halt, children} -> {children, :halt}
+      children          -> {children, :ok}
+    end
+  end
+  defp maybe_traverse({element, _needle, _fun}, :halt),
+    do: {element, :halt}
+
+  defp handle_traversed({name, attrs, children}, needle, fun) do
+    case traverse(children, needle, fun) do
+      {:halt, children} -> {:halt, {name, attrs, children}}
+      children          -> {name, attrs, children}
+    end
+  end
+
+  @doc """
+  Traverse all trees in array searching for needle, and will call function with
+  element and number times needle has been found so far.
+
+  ## Examples
+
+      iex> Premailex.Util.traverse_reduce([{"p", [], ["First paragraph"]}, {"p", [], ["Second paragraph"]}], "p", fn({name, attrs, _children}, acc) -> {name, attrs, ["Updated " <> to_string(acc)]} end)
+      {[{"p", [], ["Updated 0"]}, {"p", [], ["Updated 1"]}], 2}
+  """
+  @spec traverse_reduce(list, needle, function) :: {html_tree, integer}
   def traverse_reduce(children, needle, fun) when is_list(children),
     do: Enum.map_reduce(children, 0, &{traverse(&1, needle, fn element -> fun.(element, &2) end), &2 + 1})
+
+  @doc """
+  Traverses tree until first match for needle.
+
+  ## Examples
+
+      iex> Premailex.Util.traverse_until_first({"div", [], [{"p", [], ["First paragraph"]}, {"p", [], ["Second paragraph"]}]}, "p", fn {name, attrs, _children} -> {name, attrs, ["Updated"]} end)
+      {"div", [], [{"p", [], ["Updated"]}, {"p", [], ["Second paragraph"]}]}
+  """
+  @spec traverse_until_first(html_tree, needle, function) :: html_tree
+  def traverse_until_first(html, needle, fun) do
+    case traverse(html, needle, &{:halt, fun.(&1)}) do
+      {:halt, html} -> html
+      html          -> html
+    end
+  end
 end

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -15,6 +15,8 @@ p    {color: #000 !important; font-size:12px; background-color:#000;}
 
 a {color: #e95757; text-decoration: underline;}
 a:hover	{text-decoration: underline;}
+
+p.duplicate {color: blue;}
 """
 
   @input """
@@ -34,6 +36,7 @@ a:hover	{text-decoration: underline;}
       <td align="center">
         <p>First paragraph</p>
         <p><a href="#" style="color:#999999; font-size:12px;">Test link</a></p>
+        <p class="duplicate">Testing duplicate</p>
       </td>
     </tr>
   </table>
@@ -45,7 +48,8 @@ a:hover	{text-decoration: underline;}
           <tr align="center">
             <td>
               <h1 style="font-size:24px; line-height:24px !important; padding-bottom:8px; color: #2eac6d;">Heading</h1>
-              <p style="color: #fff;background-color:#fff !important;font-size:11px;"><p>
+              <p style="color: #fff;background-color:#fff !important;font-size:11px;"></p>
+              <p class="duplicate">Testing duplicate</p>
             </td>
             <td align="right" valign="bottom"></td>
           </tr>
@@ -79,5 +83,6 @@ a:hover	{text-decoration: underline;}
     assert parsed =~ "<h1 style=\"color:#2eac6d;font-size:24px;line-height:24px !important;margin:0;padding:0;padding-bottom:8px;\">"
     assert parsed =~ "<p style=\"background-color:#fff;color:#000 !important;font-family:Arial, sans-serif;font-size:16px;font-weight:bold;line-height:22px;margin:0;padding:0;\">First paragraph"
     assert parsed =~ "<p style=\"background-color:#fff;color:#000 !important;font-family:Arial, sans-serif;font-size:13px;line-height:22px;margin:0;padding:0;\">"
+    refute parsed =~ "[SPEC="
   end
 end

--- a/test/premailex/util_test.exs
+++ b/test/premailex/util_test.exs
@@ -1,0 +1,14 @@
+defmodule Premailex.UtilTest do
+  use ExUnit.Case
+  doctest Premailex.Util
+
+  test "traverse_until_first/3 deep nested" do
+    div_children = [{"p", [], ["Paragraph"]}, {"p", [], ["Paragraph"]}]
+    html = {"div", [], [{"div", [], div_children}, {"div", [], div_children}]}
+    needle = {"p", [], ["Paragraph"]}
+
+    result = Premailex.Util.traverse_until_first(html, needle, fn {name, attrs, _children} -> {name, attrs, ["Updated"]} end)
+
+    assert result == {"div", [], [{"div", [], [{"p", [], ["Updated"]}, {"p", [], ["Paragraph"]}]}, {"div", [], [{"p", [], ["Paragraph"]}, {"p", [], ["Paragraph"]}]}]}
+  end
+end


### PR DESCRIPTION
Resolves #2 

The issue occurred because if there're multiple identical DOM elements, it will traverse the whole HTML document and parse children before parent.

E.g.:

```html
  <table style="[SPEC=...">
    <tr style="[SPEC=...">
      <td align="center" style="[SPEC=...">
        <p class="different" style="[SPEC=...">Something in table a</p>
        <p class="duplicate" style="[SPEC=...">Duplicate</p>
      </td>
    </tr>
  </table>

  <table style="[SPEC=...">
    <tr style="[SPEC=...">
      <td align="center" style="[SPEC=...">
        <p class="different" style="[SPEC=...">Something in table b</p>
        <p class="duplicate" style="[SPEC=...">Duplicate</p>
      </td>
    </tr>
  </table>
```

In the above example, it would first look up all elements with `style` attribute, then it would loop through that list and update-merge the styles. But when it gets to the first `<p class="duplicate" style="[SPEC=...">Duplicate</p>` it would also update the second `<p class="duplicate" style="[SPEC=...">Duplicate</p>` because it's identical. Now the stored needle for all parent elements of the second `<p>` element can't be found anymore because the child has changed.