### PR TITLE
Use HTMLParser for all floki calls

### DIFF
--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -3,6 +3,8 @@ defmodule Premailex do
   Documentation for Premailex.
   """
 
+  alias Premailex.HTMLParser
+
   @doc """
   Adds inline styles to an HTML string
 
@@ -29,7 +31,7 @@ defmodule Premailex do
   @spec to_text(String.t()) :: String.t()
   def to_text(html) do
     html
-    |> Floki.find("body")
+    |> HTMLParser.all("body")
     |> Premailex.HTMLToPlainText.process()
   end
 end

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -39,7 +39,7 @@ defmodule Premailex.HTMLInlineStyles do
 
   defp add_rule_set_to_html(%{selector: selector, rules: rules, specificity: specificity}, html) do
     html
-    |> Floki.find(selector)
+    |> HTMLParser.all(selector)
     |> Enum.reduce(html, &update_style_for_html(&2, &1, rules, specificity))
   end
 
@@ -73,7 +73,7 @@ defmodule Premailex.HTMLInlineStyles do
 
   defp normalize_style(html) do
     html
-    |> Floki.find("[style]")
+    |> HTMLParser.all("[style]")
     |> Enum.reduce(html, &merge_styles(&2, &1))
   end
 

--- a/lib/premailex/html_parser.ex
+++ b/lib/premailex/html_parser.ex
@@ -4,6 +4,7 @@ defmodule Premailex.HTMLParser do
   """
 
   @default_parser Premailex.HTMLParser.Floki
+  @type html_tree :: tuple | list
 
   @doc """
   Parses a HTML string into an HTML tree.
@@ -13,7 +14,7 @@ defmodule Premailex.HTMLParser do
       iex> Premailex.HTMLParser.parse("<html><head></head><body><h1>Title</h1></body></html>")
       {"html", [], [{"head", [], []}, {"body", [], [{"h1", [], ["Title"]}]}]}
   """
-  @spec parse(String.t()) :: tuple
+  @spec parse(String.t()) :: html_tree
   def parse(html) do
     apply(parser(), :parse, [html])
   end
@@ -26,7 +27,7 @@ defmodule Premailex.HTMLParser do
       iex> Premailex.HTMLParser.all({"html", [], [{"head", [], []}, {"body", [], [{"h1", [], ["Title"]}]}]}, "h1")
       [{"h1", [], ["Title"]}]
   """
-  @spec all(tuple, String.t()) :: [tuple]
+  @spec all(html_tree, String.t()) :: [tuple]
   def all(tree, selector) do
     apply(parser(), :all, [tree, selector])
   end
@@ -39,9 +40,22 @@ defmodule Premailex.HTMLParser do
       iex> Premailex.HTMLParser.to_string({"html", [], [{"head", [], []}, {"body", [], [{"h1", [], ["Title"]}]}]})
       "<html><head></head><body><h1>Title</h1></body></html>"
   """
-  @spec to_string(tuple) :: String.t()
+  @spec to_string(html_tree) :: String.t()
   def to_string(tree) do
     apply(parser(), :to_string, [tree])
+  end
+
+  @doc """
+  Extracts text elements from the HTML tree.
+
+  ## Examples
+
+      iex> Premailex.HTMLParser.text({"html", [], [{"head", [], []}, {"body", [], [{"h1", [], ["Title"]}]}]})
+      "Title"
+  """
+  @spec text(html_tree) :: String.t()
+  def text(tree) do
+    apply(parser(), :text, [tree])
   end
 
   defp parser() do

--- a/lib/premailex/html_parser.ex
+++ b/lib/premailex/html_parser.ex
@@ -27,7 +27,7 @@ defmodule Premailex.HTMLParser do
       iex> Premailex.HTMLParser.all({"html", [], [{"head", [], []}, {"body", [], [{"h1", [], ["Title"]}]}]}, "h1")
       [{"h1", [], ["Title"]}]
   """
-  @spec all(html_tree, String.t()) :: [tuple]
+  @spec all(html_tree, String.t()) :: [html_tree]
   def all(tree, selector) do
     apply(parser(), :all, [tree, selector])
   end

--- a/lib/premailex/html_parser/floki.ex
+++ b/lib/premailex/html_parser/floki.ex
@@ -2,22 +2,28 @@ defmodule Premailex.HTMLParser.Floki do
   @moduledoc """
   API connection with Floki
   """
+  alias Premailex.HTMLParser
 
   @doc false
-  @spec parse(String.t()) :: tuple
+  @spec parse(String.t()) :: HTMLParser.html_tree()
   def parse(html) do
     Floki.parse(html)
   end
 
   @doc false
-  @spec all(tuple, String.t()) :: [tuple]
+  @spec all(HTMLParser.html_tree(), String.t()) :: [HTMLParser.html_tree()]
   def all(tree, selector) do
     Floki.find(tree, selector)
   end
 
   @doc false
-  @spec to_string(tuple) :: String.t()
+  @spec to_string(HTMLParser.html_tree()) :: String.t()
   def to_string(tree) do
     Floki.raw_html(tree)
+  end
+
+  @spec text(HTMLParser.html_tree()) :: String.t()
+  def text(tree) do
+    Floki.text(tree)
   end
 end

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -3,10 +3,13 @@ defmodule Premailex.HTMLParser.Meeseeks do
   API connection with Meeseeks
   """
 
+  require Logger
   import Meeseeks.CSS
+  alias Premailex.HTMLParser
+  alias Meeseeks.{Selector.CSS.Parser.ParseError}
 
   @doc false
-  @spec parse(String.t()) :: tuple
+  @spec parse(String.t()) :: HTMLParser.html_tree()
   def parse(html) do
     html
     |> Meeseeks.parse()
@@ -15,21 +18,52 @@ defmodule Premailex.HTMLParser.Meeseeks do
       [html] -> html
       html -> html
     end
+    |> sanitize()
   end
 
   @doc false
-  @spec all(tuple, String.t()) :: [tuple]
+  @spec all(HTMLParser.html_tree(), String.t()) :: [HTMLParser.html_tree()]
   def all(tree, selector) do
-    tree
-    |> Meeseeks.all(css("#{selector}"))
-    |> Enum.map(&Meeseeks.tree/1)
+    try do
+      tree
+      |> Meeseeks.all(css("#{selector}"))
+      |> Enum.map(&Meeseeks.tree/1)
+    rescue
+      e in ParseError ->
+        Logger.warn("Meeseeks CSS ParseError: " <> e.message)
+        []
+    end
   end
 
   @doc false
-  @spec to_string(tuple) :: String.t()
+  @spec to_string(HTMLParser.html_tree()) :: String.t()
   def to_string(tree) do
     tree
     |> Meeseeks.parse()
     |> Meeseeks.html()
   end
+
+  @doc false
+  @spec text(HTMLParser.html_tree()) :: String.t()
+  def text(text) when is_binary(text), do: text
+  def text(list) when is_list(list), do: Enum.map_join(list, "", &text/1)
+  def text({_element, _attrs, children}), do: text(children)
+
+  defp sanitize(list) when is_list(list) do
+    list
+    |> Enum.map(&sanitize/1)
+    |> Enum.reject(&is_empty?/1)
+  end
+
+  defp sanitize({elem, attr, children}) do
+    {elem, attr, sanitize(children)}
+  end
+
+  defp sanitize(any), do: any
+
+  defp is_empty?(text) when is_binary(text) do
+    String.trim(text) == ""
+  end
+
+  defp is_empty?(_any), do: false
 end

--- a/lib/premailex/util.ex
+++ b/lib/premailex/util.ex
@@ -3,8 +3,8 @@ defmodule Premailex.Util do
   Module that contains utility functions.
   """
 
-  @type html_tree :: tuple | list
-  @type needle :: binary | tuple | list
+  @type html_tree :: Premailex.HTMLParser.html_tree()
+  @type needle :: binary | html_tree
 
   @doc """
   Traverses tree searching for needle, and will call provided function on


### PR DESCRIPTION
Continuing #10 (and discussion in #9), this will move all `Floki` method calls to `HTMLParser`.