### PR TITLE
Whitespace consecutive tags

### DIFF
--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -6,7 +6,7 @@ defmodule Premailex do
   alias Premailex.HTMLParser
 
   @doc """
-  Adds inline styles to an HTML string
+  Adds inline styles to an HTML string.
 
   ## Examples
 

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -5,7 +5,9 @@ defmodule Premailex.HTMLInlineStyles do
 
   alias Premailex.{CSSParser, HTMLParser, Util}
 
-  @doc false
+  @doc """
+  Processes an HTML string adding inline styles.
+  """
   @spec process(String.t()) :: String.t()
   def process(html) do
     tree = HTMLParser.parse(html)

--- a/lib/premailex/html_parser/floki.ex
+++ b/lib/premailex/html_parser/floki.ex
@@ -7,7 +7,9 @@ defmodule Premailex.HTMLParser.Floki do
   @doc false
   @spec parse(String.t()) :: HTMLParser.html_tree()
   def parse(html) do
-    Floki.parse(html)
+    html
+    |> retain_inline_whitespace()
+    |> Floki.parse()
   end
 
   @doc false
@@ -26,4 +28,10 @@ defmodule Premailex.HTMLParser.Floki do
   def text(tree) do
     Floki.text(tree)
   end
+
+  # """
+  # This is a tempory fix until mochweb (or floki) has been updated
+  # to correctly handle whitespace text nodes: https://github.com/mochi/mochiweb/issues/166
+  # """
+  defp retain_inline_whitespace(html), do: String.replace(html, ~r/\>[ ]+\</, ">&#32;<")
 end

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -18,7 +18,6 @@ defmodule Premailex.HTMLParser.Meeseeks do
       [html] -> html
       html -> html
     end
-    |> sanitize()
   end
 
   @doc false
@@ -48,22 +47,4 @@ defmodule Premailex.HTMLParser.Meeseeks do
   def text(text) when is_binary(text), do: text
   def text(list) when is_list(list), do: Enum.map_join(list, "", &text/1)
   def text({_element, _attrs, children}), do: text(children)
-
-  defp sanitize(list) when is_list(list) do
-    list
-    |> Enum.map(&sanitize/1)
-    |> Enum.reject(&is_empty?/1)
-  end
-
-  defp sanitize({elem, attr, children}) do
-    {elem, attr, sanitize(children)}
-  end
-
-  defp sanitize(any), do: any
-
-  defp is_empty?(text) when is_binary(text) do
-    String.trim(text) == ""
-  end
-
-  defp is_empty?(_any), do: false
 end

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -50,6 +50,7 @@ defmodule Premailex.HTMLInlineStylesTest do
                 <h1 style="font-size:24px; line-height:24px !important; padding-bottom:8px; color: #2eac6d;">Heading</h1>
                 <p style="color: #fff;background-color:#fff !important;font-size:11px;"></p>
                 <p class="duplicate">Testing duplicate</p>
+                <p><span>consecutive</span> <span>tags</span></p>
               </td>
               <td align="right" valign="bottom"></td>
             </tr>
@@ -92,6 +93,9 @@ defmodule Premailex.HTMLInlineStylesTest do
 
     assert parsed =~
              "<p style=\"background-color:#fff;color:#000 !important;font-family:Arial, sans-serif;font-size:13px;line-height:22px;margin:0;padding:0;\">"
+
+    # Ensure that whitespace is maintained when it would affect display
+    assert parsed =~ "<span>consecutive</span> <span>tags</span>"
 
     refute parsed =~ "[SPEC="
   end

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -50,7 +50,7 @@ defmodule Premailex.HTMLInlineStylesTest do
                 <h1 style="font-size:24px; line-height:24px !important; padding-bottom:8px; color: #2eac6d;">Heading</h1>
                 <p style="color: #fff;background-color:#fff !important;font-size:11px;"></p>
                 <p class="duplicate">Testing duplicate</p>
-                <p><span>consecutive</span> <span>tags</span></p>
+                <p><span>Test</span> <span>consecutive</span> <span>tags</span></p>
               </td>
               <td align="right" valign="bottom"></td>
             </tr>
@@ -66,7 +66,7 @@ defmodule Premailex.HTMLInlineStylesTest do
     {:ok, bypass: bypass}
   end
 
-  test "parse to text", %{bypass: bypass} do
+  test "process/1", %{bypass: bypass} do
     input =
       @input
       |> String.replace("STYLESHEET_URL", "http://localhost:#{bypass.port}/styles.css")
@@ -95,7 +95,7 @@ defmodule Premailex.HTMLInlineStylesTest do
              "<p style=\"background-color:#fff;color:#000 !important;font-family:Arial, sans-serif;font-size:13px;line-height:22px;margin:0;padding:0;\">"
 
     # Ensure that whitespace is maintained when it would affect display
-    assert parsed =~ "<span>consecutive</span> <span>tags</span>"
+    assert parsed =~ "<span>Test</span> <span>consecutive</span> <span>tags</span>"
 
     refute parsed =~ "[SPEC="
   end

--- a/test/premailex/html_to_plain_text_test.exs
+++ b/test/premailex/html_to_plain_text_test.exs
@@ -13,6 +13,7 @@ defmodule Premailex.HTMLToPlainTextTest do
   <p><a href="http://example.com">HTTP://EXAMPLE.COM</a></p>
   <p><a href="http://example.com"></a></p>
   <p><span>Test</span> some very long paragraph with <strong>bold</strong> and <i>italic</i> text, including an <a href="http://example.com">inline link</a>. This should break up on multiple lines.</p>
+  <p><span>Test</span> <strong>consecutive</strong> <i>tags</i>.</p>
 
   <img href="logo.png" alt="Test image" /><br/>
   <img href="logo.png" /><br/>
@@ -84,6 +85,8 @@ defmodule Premailex.HTMLToPlainTextTest do
   Test some very long paragraph with bold and italic text,
   including an inline link (http://example.com). This should break
   up on multiple lines.
+
+  Test consecutive tags.
 
   Test image
 

--- a/test/premailex/html_to_plain_text_test.exs
+++ b/test/premailex/html_to_plain_text_test.exs
@@ -13,7 +13,7 @@ defmodule Premailex.HTMLToPlainTextTest do
   <p><a href="http://example.com">HTTP://EXAMPLE.COM</a></p>
   <p><a href="http://example.com"></a></p>
   <p><span>Test</span> some very long paragraph with <strong>bold</strong> and <i>italic</i> text, including an <a href="http://example.com">inline link</a>. This should break up on multiple lines.</p>
-  <p><span>Test</span> <strong>consecutive</strong> <i>tags</i>.</p>
+  <p><span>Test</span>   <strong>consecutive</strong> <i>tags</i>.</p>
 
   <img href="logo.png" alt="Test image" /><br/>
   <img href="logo.png" /><br/>


### PR DESCRIPTION
There's an issue with whitespace being ignored with inline consecutive tags.

The issue is that Floki ignores all whitespace between tags and Meeseeks preserves all whitespace. We need whitespace text nodes [to only be preserved](https://medium.com/@patrickbrosset/when-does-white-space-matter-in-html-b90e8a7cdd33) in lists that consists of inline-block tags.

## Examples

Original:
```html
<p><span>consective</span> <span>tags</span></p>
```

HTMLToPlainText:
```html
consectivetags
```

HTMLInlineStyles:
```html
<p><span>consective</span><span>tags</span></p>
````