### PR TITLE
Make CSS selector for inlining configurable

### DIFF
--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -14,9 +14,9 @@ defmodule Premailex do
       "<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"background-color:#fff;color:#000;\\\">Text</p></body></html>"
 
   """
-  @spec to_inline_css(String.t()) :: String.t()
-  def to_inline_css(html) do
-    Premailex.HTMLInlineStyles.process(html)
+  @spec to_inline_css(String.t(), String.t()) :: String.t()
+  def to_inline_css(html, css_selector \\ "style,link[rel=\"stylesheet\"][href]") do
+    Premailex.HTMLInlineStyles.process(html, css_selector)
   end
 
   @doc """

--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -14,9 +14,9 @@ defmodule Premailex do
       "<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"background-color:#fff;color:#000;\\\">Text</p></body></html>"
 
   """
-  @spec to_inline_css(String.t(), String.t()) :: String.t()
-  def to_inline_css(html, css_selector \\ "style,link[rel=\"stylesheet\"][href]") do
-    Premailex.HTMLInlineStyles.process(html, css_selector)
+  @spec to_inline_css(String.t(), Keyword.t()) :: String.t()
+  def to_inline_css(html, options \\ []) do
+    Premailex.HTMLInlineStyles.process(html, options)
   end
 
   @doc """

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -7,11 +7,14 @@ defmodule Premailex.HTMLInlineStyles do
 
   @doc """
   Processes an HTML string adding inline styles.
+
+  Options:
+    * `css_selector` - the style tags to be processed for inline styling, defaults to `style,link[rel="stylesheet"][href]`
   """
   @spec process(String.t(), Keyword.t()) :: String.t()
   def process(html, options \\ []) do
     css_selector = Keyword.get(options, :css_selector, "style,link[rel=\"stylesheet\"][href]")
-    
+
     tree = HTMLParser.parse(html)
 
     tree

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -8,8 +8,10 @@ defmodule Premailex.HTMLInlineStyles do
   @doc """
   Processes an HTML string adding inline styles.
   """
-  @spec process(String.t(), String.t()) :: String.t()
-  def process(html, css_selector) do
+  @spec process(String.t(), Keyword.t()) :: String.t()
+  def process(html, options \\ []) do
+    css_selector = Keyword.get(options, :css_selector, "style,link[rel=\"stylesheet\"][href]")
+    
     tree = HTMLParser.parse(html)
 
     tree

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -8,12 +8,12 @@ defmodule Premailex.HTMLInlineStyles do
   @doc """
   Processes an HTML string adding inline styles.
   """
-  @spec process(String.t()) :: String.t()
-  def process(html) do
+  @spec process(String.t(), String.t()) :: String.t()
+  def process(html, css_selector) do
     tree = HTMLParser.parse(html)
 
     tree
-    |> HTMLParser.all("style,link[rel=\"stylesheet\"][href]")
+    |> HTMLParser.all(css_selector)
     |> Enum.map(&load_css(&1))
     |> Enum.filter(&(!is_nil(&1)))
     |> Enum.reduce([], &Enum.concat(&1, &2))

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -6,7 +6,7 @@ defmodule Premailex.HTMLParser.Meeseeks do
   require Logger
   import Meeseeks.CSS
   alias Premailex.HTMLParser
-  alias Meeseeks.{Selector.CSS.Parser.ParseError}
+  alias Meeseeks.Selector.CSS.Parser.ParseError
 
   @doc false
   @spec parse(String.t()) :: HTMLParser.html_tree()

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -80,7 +80,7 @@ defmodule Premailex.HTMLInlineStylesTest do
       Plug.Conn.resp(conn, 500, "{}")
     end)
 
-    parsed = Premailex.HTMLInlineStyles.process(input, "style,link[rel=\"stylesheet\"][href]")
+    parsed = Premailex.HTMLInlineStyles.process(input)
 
     assert parsed =~
              "<body style=\"color:#333333;font-family:Arial, sans-serif;font-size:14px;line-height:22px;\">"

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -80,7 +80,7 @@ defmodule Premailex.HTMLInlineStylesTest do
       Plug.Conn.resp(conn, 500, "{}")
     end)
 
-    parsed = Premailex.HTMLInlineStyles.process(input)
+    parsed = Premailex.HTMLInlineStyles.process(input, "style,link[rel=\"stylesheet\"][href]")
 
     assert parsed =~
              "<body style=\"color:#333333;font-family:Arial, sans-serif;font-size:14px;line-height:22px;\">"


### PR DESCRIPTION
Extracted from https://github.com/danschultzer/premailex/pull/9/files. Allows users of the library to pass their own style selectors to be used by the engine.