### PR TITLE
Remove inline css from markup

### DIFF
--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -11,7 +11,7 @@ defmodule Premailex do
   ## Examples
 
       iex> Premailex.to_inline_css("<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"color: #000;\\\">Text</p></body></html>")
-      "<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"background-color:#fff;color:#000;\\\">Text</p></body></html>"
+      "<html><head></head><body><p style=\\\"background-color:#fff;color:#000;\\\">Text</p></body></html>"
 
   """
   @spec to_inline_css(String.t(), String.t()) :: String.t()

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -19,6 +19,7 @@ defmodule Premailex.HTMLInlineStyles do
     |> Enum.reduce([], &Enum.concat(&1, &2))
     |> Enum.reduce(tree, &add_rule_set_to_html(&1, &2))
     |> normalize_style()
+    |> HTMLParser.delete_matching(css_selector)
     |> HTMLParser.to_string()
   end
 

--- a/lib/premailex/html_parser.ex
+++ b/lib/premailex/html_parser.ex
@@ -32,6 +32,11 @@ defmodule Premailex.HTMLParser do
     apply(parser(), :all, [tree, selector])
   end
 
+  @spec delete_matching(html_tree, String.t()) :: [html_tree]
+  def delete_matching(tree, selector) do
+    apply(parser(), :delete_matching, [tree, selector])
+  end
+
   @doc """
   Turns an HTML tree into a string.
 

--- a/lib/premailex/html_parser/floki.ex
+++ b/lib/premailex/html_parser/floki.ex
@@ -19,6 +19,12 @@ defmodule Premailex.HTMLParser.Floki do
   end
 
   @doc false
+  @spec delete_matching(HTMLParser.html_tree(), String.t()) :: [HTMLParser.html_tree()]
+  def delete_matching(tree, selector) do
+    Floki.filter_out(tree, selector)
+  end
+
+  @doc false
   @spec to_string(HTMLParser.html_tree()) :: String.t()
   def to_string(tree) do
     Floki.raw_html(tree)

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -6,7 +6,8 @@ defmodule Premailex.HTMLParser.Meeseeks do
   require Logger
   import Meeseeks.CSS
   alias Premailex.HTMLParser
-  alias Meeseeks.{Selector.CSS.Parser.ParseError.Document}
+  alias Meeseeks.{Selector.CSS.Parser.ParseError}
+  alias Meeseeks.Document
 
   @doc false
   @spec parse(String.t()) :: HTMLParser.html_tree()

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -6,7 +6,7 @@ defmodule Premailex.HTMLParser.Meeseeks do
   require Logger
   import Meeseeks.CSS
   alias Premailex.HTMLParser
-  alias Meeseeks.{Selector.CSS.Parser.ParseError}
+  alias Meeseeks.{Selector.CSS.Parser.ParseError.Document}
 
   @doc false
   @spec parse(String.t()) :: HTMLParser.html_tree()
@@ -32,6 +32,15 @@ defmodule Premailex.HTMLParser.Meeseeks do
         Logger.warn("Meeseeks CSS ParseError: " <> e.message)
         []
     end
+  end
+
+  def delete_matching(tree, selector) do
+    tree
+    |> Meeseeks.all(css("#{selector}"))
+    |> Enum.reduce(Meeseeks.parse(tree), fn e, acc ->
+      Document.delete_node(acc, e.id)
+    end)
+    |> Meeseeks.tree()
   end
 
   @doc false

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -34,14 +34,6 @@ if Code.ensure_loaded?(Meeseeks) do
       end
     end
 
-    @doc false
-    @spec to_string(HTMLParser.html_tree()) :: String.t()
-    def to_string(tree) do
-      tree
-      |> Meeseeks.parse()
-      |> Meeseeks.html()
-    end
-
     def delete_matching(tree, selector) do
       tree
       |> Meeseeks.all(css("#{selector}"))


### PR DESCRIPTION
Includes a commit from https://github.com/danschultzer/premailex/pull/13, so this PR will get smaller once that one is merged.

Inspired by code in https://github.com/danschultzer/premailex/pull/9/files, updated to support multiple parsers.

@danschultzer 