### PR TITLE
Add optimization step for HTMLInlineStyles

### DIFF
--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -11,7 +11,7 @@ defmodule Premailex do
   ## Examples
 
       iex> Premailex.to_inline_css("<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"color: #000;\\\">Text</p></body></html>")
-      "<html><head></head><body><p style=\\\"background-color:#fff;color:#000;\\\">Text</p></body></html>"
+      "<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"background-color:#fff;color:#000;\\\">Text</p></body></html>"
 
   """
   @spec to_inline_css(String.t(), Keyword.t()) :: String.t()

--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -11,7 +11,7 @@ defmodule Premailex do
   ## Examples
 
       iex> Premailex.to_inline_css("<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"color: #000;\\\">Text</p></body></html>")
-      "<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"background-color:#fff;color:#000;\\\">Text</p></body></html>"
+      "<html><head></head><body><p style=\\\"background-color:#fff;color:#000;\\\">Text</p></body></html>"
 
   """
   @spec to_inline_css(String.t(), Keyword.t()) :: String.t()

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -24,6 +24,7 @@ defmodule Premailex.HTMLInlineStyles do
     |> Enum.reduce([], &Enum.concat(&1, &2))
     |> Enum.reduce(tree, &add_rule_set_to_html(&1, &2))
     |> normalize_style()
+    |> HTMLParser.delete_matching(css_selector)
     |> HTMLParser.to_string()
   end
 

--- a/lib/premailex/html_parser.ex
+++ b/lib/premailex/html_parser.ex
@@ -32,6 +32,11 @@ defmodule Premailex.HTMLParser do
     apply(parser(), :all, [tree, selector])
   end
 
+  @spec delete_matching(html_tree, String.t()) :: [html_tree]
+  def delete_matching(tree, selector) do
+    apply(parser(), :delete_matching, [tree, selector])
+  end
+
   @doc """
   Turns an HTML tree into a string.
 

--- a/lib/premailex/html_parser.ex
+++ b/lib/premailex/html_parser.ex
@@ -32,9 +32,17 @@ defmodule Premailex.HTMLParser do
     apply(parser(), :all, [tree, selector])
   end
 
-  @spec delete_matching(html_tree, String.t()) :: [html_tree]
-  def delete_matching(tree, selector) do
-    apply(parser(), :delete_matching, [tree, selector])
+  @doc """
+  Filters elements matching the selector from the HTML tree.
+
+  ## Examples
+
+      iex> Premailex.HTMLParser.filter([{"html", [], [{"head", [], []}, {"body", [], [{"h1", [], ["Title"]}]}]}], "h1")
+      [{"html", [], [{"head", [], []}, {"body", [], []}]}]
+  """
+  @spec filter(html_tree, String.t()) :: [html_tree]
+  def filter(tree, selector) do
+    apply(parser(), :filter, [tree, selector])
   end
 
   @doc """

--- a/lib/premailex/html_parser/floki.ex
+++ b/lib/premailex/html_parser/floki.ex
@@ -17,8 +17,8 @@ defmodule Premailex.HTMLParser.Floki do
   end
 
   @doc false
-  @spec delete_matching(HTMLParser.html_tree(), String.t()) :: [HTMLParser.html_tree()]
-  def delete_matching(tree, selector) do
+  @spec filter(HTMLParser.html_tree(), String.t()) :: [HTMLParser.html_tree()]
+  def filter(tree, selector) do
     Floki.filter_out(tree, selector)
   end
 

--- a/lib/premailex/html_parser/floki.ex
+++ b/lib/premailex/html_parser/floki.ex
@@ -17,6 +17,12 @@ defmodule Premailex.HTMLParser.Floki do
   end
 
   @doc false
+  @spec delete_matching(HTMLParser.html_tree(), String.t()) :: [HTMLParser.html_tree()]
+  def delete_matching(tree, selector) do
+    Floki.filter_out(tree, selector)
+  end
+
+  @doc false
   @spec to_string(HTMLParser.html_tree()) :: String.t()
   def to_string(tree) do
     Floki.raw_html(tree)

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -46,5 +46,14 @@ if Code.ensure_loaded?(Meeseeks) do
     def text(text) when is_binary(text), do: text
     def text(list) when is_list(list), do: Enum.map_join(list, "", &text/1)
     def text({_element, _attrs, children}), do: text(children)
+
+    def delete_matching(tree, selector) do
+      tree
+      |> Meeseeks.all(css("#{selector}"))
+      |> Enum.reduce(Meeseeks.parse(tree), fn e, acc ->
+        Document.delete_node(acc, e.id)
+      end)
+      |> Meeseeks.tree()
+    end
   end
 end

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -48,7 +48,9 @@ if Code.ensure_loaded?(Meeseeks) do
     def text(list) when is_list(list), do: Enum.map_join(list, "", &text/1)
     def text({_element, _attrs, children}), do: text(children)
 
-    def delete_matching(tree, selector) do
+    @doc false
+    @spec filter(HTMLParser.html_tree(), String.t()) :: [HTMLParser.html_tree()]
+    def filter(tree, selector) do
       tree
       |> Meeseeks.all(css("#{selector}"))
       |> Enum.reduce(Meeseeks.parse(tree), fn e, acc ->

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -6,6 +6,7 @@ if Code.ensure_loaded?(Meeseeks) do
     import Meeseeks.CSS
     alias Premailex.HTMLParser
     alias Meeseeks.Selector.CSS.Parser.ParseError
+    alias Meeseeks.Document
 
     @doc false
     @spec parse(String.t()) :: HTMLParser.html_tree()

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -112,10 +112,33 @@ defmodule Premailex.HTMLInlineStylesTest do
              "<p style=\"color:#333333;font-family:Arial, sans-serif;font-size:16px;font-weight:bold;line-height:22px;margin:0;padding:0;\">First paragraph"
   end
 
-  test "process/1 with optimize", %{input: input} do
-    parsed = Premailex.HTMLInlineStyles.process(input, optimize: true)
-
+  test "process/1 with optimize: :all", %{input: input} do
+    parsed = Premailex.HTMLInlineStyles.process(input, optimize: :all)
     refute parsed =~ "<style>"
     refute parsed =~ "<link href"
+  end
+
+  test "process/1 with optimize: :remove_style_tags", %{input: input} do
+    parsed = Premailex.HTMLInlineStyles.process(input, optimize: :remove_style_tags)
+    refute parsed =~ "<style>"
+    refute parsed =~ "<link href"
+  end
+
+  test "process/1 with optimize: [:remove_style_tags]", %{input: input} do
+    parsed = Premailex.HTMLInlineStyles.process(input, optimize: [:remove_style_tags])
+    refute parsed =~ "<style>"
+    refute parsed =~ "<link href"
+  end
+
+  test "process/1 with optimize: [:unknown]", %{input: input} do
+    parsed = Premailex.HTMLInlineStyles.process(input, optimize: [:unknown])
+    assert parsed =~ "<style>"
+    assert parsed =~ "<link href"
+  end
+
+  test "process/1 with optimize: [:none]", %{input: input} do
+    parsed = Premailex.HTMLInlineStyles.process(input, optimize: :none)
+    assert parsed =~ "<style>"
+    assert parsed =~ "<link href"
   end
 end


### PR DESCRIPTION
Adds an optimization step to `HTMLInlineStyles`:

```elixir
Premailex.to_inline_css(email, optimize: true)
```

It removes the style/link tags used for inline styling. I continued from #14, but after thinking for a while I think it makes more sense to have this as a whole optimization step. We could potentially remove whitespace too at some point, and optimize the whole HTML email.

I'm not 100% sure this should be within the scope of this library. It can be argued that optimization should be handled separately from this library.