### PR TITLE
Update Meeseeks to v0.9.0

### DIFF
--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -5,7 +5,6 @@ if Code.ensure_loaded?(Meeseeks) do
     require Logger
     import Meeseeks.CSS
     alias Premailex.HTMLParser
-    alias Meeseeks.Selector.CSS.Parser.ParseError
     alias Meeseeks.Document
 
     @doc false
@@ -28,8 +27,8 @@ if Code.ensure_loaded?(Meeseeks) do
         |> Meeseeks.all(css("#{selector}"))
         |> Enum.map(&Meeseeks.tree/1)
       rescue
-        e in ParseError ->
-          Logger.warn("Meeseeks CSS ParseError: " <> e.message)
+        e in Meeseeks.Error ->
+          Logger.warn("Meeseeks Error: " <> inspect(e))
           []
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Premailex.Mixfile do
   defp deps do
     [
       {:floki, ">= 0.19.0 or < 0.21.0"},
-      {:meeseeks, "~> 0.8", optional: true},
+      {:meeseeks, "~> 0.9", optional: true},
       {:httpoison, "~> 0.13 or ~> 1.0"},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:bypass, "~> 0.8", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -12,7 +12,7 @@
   "html_entities": {:hex, :html_entities, "0.4.0", "f2fee876858cf6aaa9db608820a3209e45a087c5177332799592142b50e89a6b", [:mix], [], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.0.0", "1f02f827148d945d40b24f0b0a89afe40bfe037171a6cf70f2486976d86921cd", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
-  "meeseeks": {:hex, :meeseeks, "0.8.0", "f22b89b538741f55f9c7b9f3e6051484f48bcdc864c8f2f25d28c965bff64fb3", [:mix], [{:meeseeks_html5ever, "~> 0.8.1", [hex: :meeseeks_html5ever, repo: "hexpm", optional: false]}], "hexpm"},
+  "meeseeks": {:hex, :meeseeks, "0.9.0", "61ad5df515e057403978672107e52af829f7b70c75a8c6a8689f95393c4985f8", [:mix], [{:meeseeks_html5ever, "~> 0.8.1", [hex: :meeseeks_html5ever, repo: "hexpm", optional: false]}], "hexpm"},
   "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.8.1", "8b10ad450d31b99408e570fab5f8e26aad9fa1cd2d6da0b99b5aa0a216809896", [:mix], [{:rustler, "~> 0.16", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], [], "hexpm"},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [], [], "hexpm"},


### PR DESCRIPTION
Meeseeks v0.9.0 makes a breaking change related to how the library handles errors, so because you rescue an error as part of your use of Meeseeks I went ahead and bumped the dependency and updated the broken bit so you won't have to think about it in the future.