### PR TITLE
Add missing parse() in to_text/1 function

### DIFF
--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -31,6 +31,7 @@ defmodule Premailex do
   @spec to_text(String.t()) :: String.t()
   def to_text(html) do
     html
+    |> HTMLParser.parse()
     |> HTMLParser.all("body")
     |> Premailex.HTMLToPlainText.process()
   end


### PR DESCRIPTION
**Changes**
* Add (probably) missing `HTMLParser.parse()` action inside pipeline in `Premailex. to_text/1` function


---
**Description**
Hi @danschultzer 

I decided to prepare this pull request because I think, inside pipeline in `Premailex.to_text/1` function you should have call `parse()` function from `HTMLParser` module. In spec `HTMLParser.all/2` you have note about `html_tree :: tuple | list` but receive simple binary (String.t()) data.