### PR TITLE
CSS style with colon in context - enable parse rules

### DIFF
--- a/lib/premailex/css_parser.ex
+++ b/lib/premailex/css_parser.ex
@@ -95,7 +95,8 @@ defmodule Premailex.CSSParser do
     rule
     |> String.trim()
     |> String.split(":")
-    |> parse_rule
+    |> prepare_rule_structure()
+    |> parse_rule()
   end
 
   defp parse_rule([directive, value]) do
@@ -109,7 +110,22 @@ defmodule Premailex.CSSParser do
   defp parse_rule([""]), do: nil
 
   defp parse_rule([value]) do
-    %{directive: "", value: String.trim(value), important?: String.contains?(value, "!important")}
+    %{
+      directive: "",
+      value: String.trim(value),
+      important?: String.contains?(value, "!important")
+    }
+  end
+
+  defp prepare_rule_structure(list) do
+    case length(list) do
+      1 -> list
+      _more ->
+        [head | tail] = list
+        value = Enum.join(tail, ":")
+
+        [head, value]
+    end
   end
 
   defp strip_comments(string) do

--- a/lib/premailex/css_parser.ex
+++ b/lib/premailex/css_parser.ex
@@ -94,8 +94,7 @@ defmodule Premailex.CSSParser do
   defp parse_rule(rule) when is_binary(rule) do
     rule
     |> String.trim()
-    |> String.split(":")
-    |> prepare_rule_parameters()
+    |> String.split(":", parts: 2)
     |> parse_rule()
   end
 
@@ -115,19 +114,6 @@ defmodule Premailex.CSSParser do
       value: String.trim(value),
       important?: String.contains?(value, "!important")
     }
-  end
-
-  defp prepare_rule_parameters(list) do
-    case length(list) do
-      1 ->
-        list
-
-      _more ->
-        [head | tail] = list
-        value = Enum.join(tail, ":")
-
-        [head, value]
-    end
   end
 
   defp strip_comments(string) do

--- a/lib/premailex/css_parser.ex
+++ b/lib/premailex/css_parser.ex
@@ -95,7 +95,7 @@ defmodule Premailex.CSSParser do
     rule
     |> String.trim()
     |> String.split(":")
-    |> prepare_rule_structure()
+    |> prepare_rule_parameters()
     |> parse_rule()
   end
 
@@ -117,9 +117,11 @@ defmodule Premailex.CSSParser do
     }
   end
 
-  defp prepare_rule_structure(list) do
+  defp prepare_rule_parameters(list) do
     case length(list) do
-      1 -> list
+      1 ->
+        list
+
       _more ->
         [head | tail] = list
         value = Enum.join(tail, ":")

--- a/test/premailex/css_parser_test.exs
+++ b/test/premailex/css_parser_test.exs
@@ -3,7 +3,7 @@ defmodule Premailex.CSSParserTest do
   doctest Premailex.CSSParser
 
   @input """
-  body, table {/* text-decoration:underline */background-color:#ffffff;color:#000000;}
+  body, table {/* text-decoration:underline */background-color:#ffffff;background-image:url('http://example.com/image.png');color:#000000;}
   div p > a:hover {color:#000000 !important;text-decoration:underline}
   /*div {
     padding:10px
@@ -14,6 +14,7 @@ defmodule Premailex.CSSParserTest do
     %{
       rules: [
         %{directive: "background-color", value: "#ffffff", important?: false},
+        %{directive: "background-image", value: "url('http://example.com/image.png')", important?: false},
         %{directive: "color", value: "#000000", important?: false}
       ],
       selector: "body",
@@ -22,6 +23,7 @@ defmodule Premailex.CSSParserTest do
     %{
       rules: [
         %{directive: "background-color", value: "#ffffff", important?: false},
+        %{directive: "background-image", value: "url('http://example.com/image.png')", important?: false},
         %{directive: "color", value: "#000000", important?: false}
       ],
       selector: "table",

--- a/test/premailex/css_parser_test.exs
+++ b/test/premailex/css_parser_test.exs
@@ -14,7 +14,11 @@ defmodule Premailex.CSSParserTest do
     %{
       rules: [
         %{directive: "background-color", value: "#ffffff", important?: false},
-        %{directive: "background-image", value: "url('http://example.com/image.png')", important?: false},
+        %{
+          directive: "background-image",
+          value: "url('http://example.com/image.png')",
+          important?: false
+        },
         %{directive: "color", value: "#000000", important?: false}
       ],
       selector: "body",
@@ -23,7 +27,11 @@ defmodule Premailex.CSSParserTest do
     %{
       rules: [
         %{directive: "background-color", value: "#ffffff", important?: false},
-        %{directive: "background-image", value: "url('http://example.com/image.png')", important?: false},
+        %{
+          directive: "background-image",
+          value: "url('http://example.com/image.png')",
+          important?: false
+        },
         %{directive: "color", value: "#000000", important?: false}
       ],
       selector: "table",


### PR DESCRIPTION
Hi @danschultzer 
I prepare new pull request with feature in `parse_rule/1` function.

Now when you have rules line `background-image: url(image_url)` simple `String.split(":")` create list with more than two parameters. After changes head from list is always `directive` and values join by `:` as second (`value`).