### PR TITLE
Follow redirects to work with http to https

### DIFF
--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -51,7 +51,7 @@ defmodule Premailex.HTMLInlineStyles do
 
   defp load_css({"link", {"href", url}}) do
     url
-    |> http_adapter().get()
+    |> http_adapter().get([], [follow_redirect: true])
     |> parse_url_response()
   end
 


### PR DESCRIPTION
There is currently issue with redirects from http to https, in those cases it won't work as body will be redirect not actual content:

Example:
```
<link rel="stylesheet" href="http://dummmy-api-test-images-standalone.dev.dummy.io/css/marketing/email.css"/>
```
will not work if it redirects to https.

My PR solves this issue by following redirect