### PR TITLE
Add HTTP adapter for HTTPoison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.4
+
+* HTTP adapter for HTTPoison that handles redirects #31 #32 (thanks @Lackoftactics)
+
 ## v0.3.3
 
 * Ignore `@media` queries  #28 #29

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -55,7 +55,7 @@ defmodule Premailex.HTMLInlineStyles do
     |> parse_url_response()
   end
 
-  defp parse_url_response({:ok, %{body: resp}}) when is_binary(resp), do: CSSParser.parse(resp)
+  defp parse_url_response({:ok, resp}) when is_binary(resp), do: CSSParser.parse(resp)
   defp parse_url_response(_), do: nil
 
   defp add_rule_set_to_html(%{selector: selector, rules: rules, specificity: specificity}, html) do
@@ -135,7 +135,7 @@ defmodule Premailex.HTMLInlineStyles do
     end
   end
 
-  @default_http_adapter HTTPoison
+  @default_http_adapter Premailex.HTTPoisonAdapter
 
   defp http_adapter do
     Application.get_env(:premailex, :http_adapter, @default_http_adapter)

--- a/lib/premailex/httpoison_adapter.ex
+++ b/lib/premailex/httpoison_adapter.ex
@@ -1,0 +1,32 @@
+defmodule Premailex.HTTPoisonAdapter do
+  @moduledoc """
+  Adapter module for HTTPoison.
+  """
+  alias HTTPoison.Response
+
+  @httpoison_opts [follow_redirect: true]
+
+  @doc """
+  Fetches an URL and returns the body if the response has a 200 HTTP status
+  code.
+
+  ## Examples
+
+      iex> Premailex.HTTPoisonAdapter.get("http://localhost:4000/styles.css")
+      {:ok, "body {color: #000;}"}
+
+      iex> Premailex.HTTPoisonAdapter.get("http://localhost:4000/nonexistant.css")
+      {:error, %HTTPoison.Response{status_code: 404}}
+
+  """
+  @spec get(String.t()) :: {:ok, String.t()} | {:error, term()}
+  def get(url) do
+    url
+    |> HTTPoison.get([], @httpoison_opts)
+    |> process()
+  end
+
+  defp process({:ok, %Response{status_code: 200, body: body}}), do: {:ok, body}
+  defp process({:ok, resp}), do: {:error, resp}
+  defp process(any), do: any
+end

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -64,10 +64,10 @@ defmodule Premailex.HTMLInlineStylesTest do
   module =
     quote do
       def get("http://localhost/styles.css"),
-        do: {:ok, %HTTPoison.Response{status_code: 200, body: unquote(@css_link_content)}}
+        do: {:ok, unquote(@css_link_content)}
 
       def get("http://localhost/invalid_styles.css"),
-        do: {:ok, %HTTPoison.Response{status_code: 404}}
+        do: {:error, %HTTPoison.Response{status_code: 404}}
     end
 
   Module.create(HTTPAdapterMock, module, Macro.Env.location(__ENV__))


### PR DESCRIPTION
This uses a HTTP adapter module instead of calling HTTPoison directly.

Resolves #31.