### PR TITLE
Preserve conditonal comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.6 (TBA)
+
+* Preserve conditional comments in `Premailex.Util.traverse/3` so they can show up in output from `Premailex.HTMLInlineStyles.process/2`
+
 ## v0.3.5 (2019-03-21)
 
 * Accept `<table>` with `<th>` elements.

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -45,6 +45,7 @@ if Code.ensure_loaded?(Meeseeks) do
     @spec text(HTMLParser.html_tree()) :: String.t()
     def text(text) when is_binary(text), do: text
     def text(list) when is_list(list), do: Enum.map_join(list, "", &text/1)
+    def text({:comment, _text}), do: ""
     def text({_element, _attrs, children}), do: text(children)
 
     @doc false

--- a/lib/premailex/util.ex
+++ b/lib/premailex/util.ex
@@ -44,6 +44,7 @@ defmodule Premailex.Util do
     end
   end
 
+  def traverse({:comment, "[if " <> _rest} = comment, _, _), do: comment
   def traverse({:comment, _}, _, _), do: ""
   def traverse(element, _, _), do: element
 

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -57,6 +57,13 @@ defmodule Premailex.HTMLInlineStylesTest do
           </table>
         </td>
       </tr>
+    </table>
+
+    <!-- This is a comment -->
+
+    <!--[if (gte mso 9)|(IE)]>
+    <hr/>
+    <![endif]-->
     </body>
   </html>
   """
@@ -100,6 +107,12 @@ defmodule Premailex.HTMLInlineStylesTest do
 
     assert parsed =~ "<style>"
     assert parsed =~ "<link href"
+
+    refute parsed =~ "This is a comment"
+
+    assert parsed =~ ~r/(#{Regex.escape("<!--[if (gte mso 9)|(IE)]>")})|(#{Regex.escape("<!-- [if (gte mso 9)|(IE)]>")})/
+    assert parsed =~ "<hr/>"
+    assert parsed =~ ~r/(#{Regex.escape("<![endif]-->")})|(#{Regex.escape("<![endif] -->")})/
   end
 
   test "process/1 with css_selector", %{input: input} do

--- a/test/premailex/html_to_plain_text_test.exs
+++ b/test/premailex/html_to_plain_text_test.exs
@@ -59,6 +59,10 @@ defmodule Premailex.HTMLToPlainTextTest do
     </tr>
   </table>
 
+  <!--[if (gte mso 9)|(IE)]>
+  <hr/>
+  <![endif]-->
+
   <!-- This is a comment -->
   """
 


### PR DESCRIPTION
This will preserve conditonal comments in inlined HTML like:

```html
<!--[if (gte mso 9)|(IE)]>
<hr/>
<![endif]-->
```

It still strips all other comments.

Resolves #36 