### PR TITLE
Support downlevel-revealed comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.7 (TBA)
+
+* Preserve downlevel-revealed conditional comments in `Premailex.Util.traverse/3`
+
 ## v0.3.6 (2019-06-22)
 
 * Preserve conditional comments in `Premailex.Util.traverse/3` so they can show up in output from `Premailex.HTMLInlineStyles.process/2`

--- a/lib/premailex/util.ex
+++ b/lib/premailex/util.ex
@@ -45,6 +45,7 @@ defmodule Premailex.Util do
   end
 
   def traverse({:comment, "[if " <> _rest} = comment, _, _), do: comment
+  def traverse({:comment, "<![endif]" <> _rest} = comment, _, _), do: comment
   def traverse({:comment, _}, _, _), do: ""
   def traverse(element, _, _), do: element
 

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -62,8 +62,12 @@ defmodule Premailex.HTMLInlineStylesTest do
     <!-- This is a comment -->
 
     <!--[if (gte mso 9)|(IE)]>
-    <hr/>
+    <p>Downlevel-hidden comment</p>
     <![endif]-->
+
+    <!--[if !mso]><!-- -->
+    <p>Downlevel-revealed comment</p>
+    <!--<![endif]-->
     </body>
   </html>
   """
@@ -111,8 +115,13 @@ defmodule Premailex.HTMLInlineStylesTest do
     refute parsed =~ "This is a comment"
 
     assert parsed =~ ~r/(#{Regex.escape("<!--[if (gte mso 9)|(IE)]>")})|(#{Regex.escape("<!-- [if (gte mso 9)|(IE)]>")})/
-    assert parsed =~ "<hr/>"
+    assert parsed =~ "<p>Downlevel-hidden comment</p>"
     assert parsed =~ ~r/(#{Regex.escape("<![endif]-->")})|(#{Regex.escape("<![endif] -->")})/
+
+    assert parsed =~ ~r/(#{Regex.escape("<!--[if !mso]><!-- -->")})|(#{Regex.escape("<!-- [if !mso]><!--  -->")})/
+    assert parsed =~
+            "<p style=\"background-color:#000;color:#000 !important;font-family:Arial, sans-serif;font-size:16px;font-weight:bold;line-height:22px;margin:0;padding:0;\">Downlevel-revealed comment</p>"
+    assert parsed =~ ~r/(#{Regex.escape("<!--<![endif]-->")})|(#{Regex.escape("<!-- <![endif] -->")})/
   end
 
   test "process/1 with css_selector", %{input: input} do

--- a/test/premailex/html_to_plain_text_test.exs
+++ b/test/premailex/html_to_plain_text_test.exs
@@ -60,8 +60,12 @@ defmodule Premailex.HTMLToPlainTextTest do
   </table>
 
   <!--[if (gte mso 9)|(IE)]>
-  <hr/>
+  <p>Downlevel-hidden comment</p>
   <![endif]-->
+
+  <!--[if !mso]><!-- -->
+  <p>Downlevel-revealed comment</p>
+  <!--<![endif]-->
 
   <!-- This is a comment -->
   """
@@ -116,6 +120,8 @@ defmodule Premailex.HTMLToPlainTextTest do
   Header key Header value
   Key: Value
   Key 2: Nested key: Value
+
+  Downlevel-revealed comment
   """
 
   test "process/1" do


### PR DESCRIPTION
Logger is outputting info to discourage conditional comments

Resolves #36 