### PR TITLE
Only traverse once for each CSS selector match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.10 (TBA)
+
+* Fixed bug where the inline styles where applied to more than the first match causing in some cases styles to be missing for subsequent parent elements
+
 ## v0.3.10 (2020-01-09)
 
 * Support floki up to `v0.24.x`

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -69,7 +69,7 @@ defmodule Premailex.HTMLInlineStyles do
   end
 
   defp update_style_for_html(html, needle, rules, specificity) do
-    Util.traverse(html, needle, &update_style_for_element(&1, rules, specificity))
+    Util.traverse_until_first(html, needle, &update_style_for_element(&1, rules, specificity))
   end
 
   defp update_style_for_element({name, attrs, children}, rules, specificity) do

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -19,6 +19,7 @@ defmodule Premailex.HTMLInlineStylesTest do
   a:hover	{text-decoration: underline;}
 
   p.duplicate {color: blue;}
+  .same-match {color:yellow;}
   """
 
   @input """
@@ -70,6 +71,22 @@ defmodule Premailex.HTMLInlineStylesTest do
     <!--[if !mso]><!-- -->
     <p>Downlevel-revealed comment</p>
     <!--<![endif]-->
+
+    <div class="match-order-test-1 same-match">
+      <span class="same-match">1</span>
+    </div>
+    <div class="match-order-test-2 same-match">
+      <span class="same-match">1</span>
+    </div>
+    <div class="match-order-test-3 same-match">
+      <span class="same-match">1</span>
+      <span class="same-match">2</span>
+    </div>
+    <div class="encapsulated">
+      <div class="match-order-test-4 same-match">
+        <span class="same-match">1</span>
+      </div>
+    </div>
     </body>
   </html>
   """
@@ -124,6 +141,11 @@ defmodule Premailex.HTMLInlineStylesTest do
     assert parsed =~
             "<p style=\"background-color:#000;color:#000 !important;font-family:Arial, sans-serif;font-size:16px;font-weight:bold;line-height:22px;margin:0;padding:0;\">Downlevel-revealed comment</p>"
     assert parsed =~ ~r/(#{Regex.escape("<!--<![endif]-->")})|(#{Regex.escape("<!-- <![endif] -->")})/
+
+    assert parsed =~ "<div class=\"match-order-test-1 same-match\" style=\"color:yellow;\">"
+    assert parsed =~ "<div class=\"match-order-test-2 same-match\" style=\"color:yellow;\">"
+    assert parsed =~ "<div class=\"match-order-test-3 same-match\" style=\"color:yellow;\">"
+    assert parsed =~ "<div class=\"match-order-test-4 same-match\" style=\"color:yellow;\">"
   end
 
   test "process/1 with css_selector", %{input: input} do


### PR DESCRIPTION
Resolves #52 

The issue is that when all matching elements are found with `HTMLParser.all/2`, it'll be in the order the selector matched.

You may have something like:

```html
<div class="match-order-test-1 same-match">
  <span class="same-match">1</span>
</div>
<div class="match-order-test-2 same-match">
  <span class="same-match">1</span>
</div>
```

When you match on `.same-match` the order of the found elements would be first the `.match-order-test-1` div, then the `.same-match` child in that div, and then the `.match-order-test-2` div. Since `Util.traverse/2` was used to iterate through the HTML, it would mean that the child in the `.match-order-test-2` was being updated before the `.match-order-test-2` div, because the `.same-match` child is identical. This would result in the subsequent match for `.match-order-test-2` no longer working as the children has been updated.

Since we already have all matching elements with `HTMLParser.all/2`, we only need to find and update the first matching element.