### PR TITLE
Fix spec on Premailex.HTMLInlineStyles.process/3

### DIFF
--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -15,7 +15,7 @@ defmodule Premailex.HTMLInlineStyles do
       * `:all` - apply all optimization steps
       * `:remove_style_tags` - Remove style tags (can be combined in a list)
   """
-  @spec process(String.t() | HTMLParser.html_tree(), [CSSParser.rule_set()], Keyword.t()) :: String.t()
+  @spec process(String.t() | HTMLParser.html_tree(), [CSSParser.rule_set()] | nil, Keyword.t() | nil) :: String.t()
   def process(html_or_html_tree, css_rule_sets_or_options \\ nil, options \\ nil)
   def process(html, css_rule_sets_or_options, options) when is_binary(html) do
     html


### PR DESCRIPTION
The recent updates to `Premailex.HTMLInlineStyles.process/3` changed the spec, but the spec doesn't match the actual allowed arguments. Specifically, `process/1` and `process/2` default to `nil` for the 2nd/3rd arguments, but the spec doesn't allow `nil` there. This is causing "no local return" dialyzer warnings to bubble up into any app calling this function.

I updated the spec to allow `nil` for those arguments.