### PR TITLE
Fix hexdocs link

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule Premailex.Mixfile do
   defp docs do
     [
       source_ref: "v#{@version}",
-      main: "README",
+      main: "readme",
       canonical: "http://hexdocs.pm/premailex",
       source_url: "https://github.com/danschultzer/premailex",
       extras: [


### PR DESCRIPTION
I'm getting 404s trying to access the docs from the hex package page (https://hexdocs.pm/premailex/0.3.12/README.html).

I think it is caused by the redirect to `README.html` (all caps) in from the generated `index.html` page:

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <title>Premailex v0.3.12 — Documentation</title>
    <meta http-equiv="refresh" content="0; url=README.html">
    <meta name="generator" content="ExDoc v0.22.6">
  <script async defer data-domain="hexdocs.pm" src="https://stats.hexdocs.pm/js/index.js"></script></head>
  <body></body>
</html>
```

When the docs are generated, the file is lowercase `readme.html`.
I can only assume `hexdocs.pm` is case sensitive, since a request to https://hexdocs.pm/premailex/0.3.12/readme.html works.

This PR changes the `main` entry in the mix.exs to a lowercase `readme`, which produces this index page:

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <title>Premailex v0.3.12 — Documentation</title>
    <meta http-equiv="refresh" content="0; url=readme.html">
    <meta name="generator" content="ExDoc v0.22.6">
  </head>
  <body></body>
</html>
```

