### PR TITLE
Add spaces between inline CSS : and ;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.16 (TBA)
+
+* `Premailex.CSSParser.to_string/1` now adds whitespace between inline style rules
+
 ## v0.3.15 (2022-03-24)
 
 * Fixed invalid spec in `Premailex.Util.traverse/3`

--- a/lib/premailex.ex
+++ b/lib/premailex.ex
@@ -11,7 +11,7 @@ defmodule Premailex do
   ## Examples
 
       iex> Premailex.to_inline_css("<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"color: #000;\\\">Text</p></body></html>")
-      "<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"background-color:#fff;color:#000;\\\">Text</p></body></html>"
+      "<html><head><style>p{background-color: #fff;}</style></head><body><p style=\\\"background-color: #fff; color: #000;\\\">Text</p></body></html>"
 
   """
   @spec to_inline_css(String.t(), Keyword.t()) :: String.t()

--- a/lib/premailex/css_parser.ex
+++ b/lib/premailex/css_parser.ex
@@ -176,14 +176,15 @@ defmodule Premailex.CSSParser do
   ## Examples
 
       iex> Premailex.CSSParser.to_string([%{directive: "background-color", value: "#fff"}, %{directive: "color", value: "#000"}])
-      "background-color:#fff;color:#000;"
+      "background-color: #fff; color: #000;"
 
       iex> Premailex.CSSParser.to_string(%{directive: "background-color", value: "#fff"})
-      "background-color:#fff;"
+      "background-color: #fff;"
   """
   @spec to_string([rule]) :: String.t()
-  def to_string(rules) when is_list(rules),
-    do: Enum.reduce(rules, "", &"#{&2} #{__MODULE__.to_string(&1)}")
+  def to_string(rules) when is_list(rules) do
+    Enum.map_join(rules, " ", &__MODULE__.to_string/1)
+  end
 
   def to_string(%{directive: directive, value: value}), do: "#{directive}: #{value};"
 

--- a/lib/premailex/css_parser.ex
+++ b/lib/premailex/css_parser.ex
@@ -183,9 +183,9 @@ defmodule Premailex.CSSParser do
   """
   @spec to_string([rule]) :: String.t()
   def to_string(rules) when is_list(rules),
-    do: Enum.reduce(rules, "", &"#{&2}#{__MODULE__.to_string(&1)}")
+    do: Enum.reduce(rules, "", &"#{&2} #{__MODULE__.to_string(&1)}")
 
-  def to_string(%{directive: directive, value: value}), do: "#{directive}:#{value};"
+  def to_string(%{directive: directive, value: value}), do: "#{directive}: #{value};"
 
   defp calculate_specificity(selector) do
     b = ~r/\#/ |> Regex.scan(selector) |> length()

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -112,19 +112,19 @@ defmodule Premailex.HTMLInlineStylesTest do
   test "process/3", %{input: input} do
     parsed = Premailex.HTMLInlineStyles.process(input)
 
-    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color:black;\">"
+    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color: black;\">"
 
     assert parsed =~
-             "<body style=\"color:#333333;font-family:Arial, sans-serif;font-size:14px;line-height:22px;\">"
+             "<body style=\"color: #333333; font-family: Arial, sans-serif; font-size: 14px; line-height: 22px;\">"
 
     assert parsed =~
-             "<h1 style=\"color:#2eac6d;font-size:24px;line-height:24px !important;margin:0;padding:0;padding-bottom:8px;\">"
+             "<h1 style=\"color: #2eac6d; font-size: 24px; line-height: 24px !important; margin: 0; padding: 0; padding-bottom: 8px;\">"
 
     assert parsed =~
-             "<p style=\"background-color:#fff;color:#000 !important;font-family:Arial, sans-serif;font-size:16px;font-weight:bold;line-height:22px;margin:0;padding:0;\">First paragraph"
+             "<p style=\"background-color: #fff; color: #000 !important; font-family: Arial, sans-serif; font-size: 16px; font-weight: bold; line-height: 22px; margin: 0; padding: 0;\">First paragraph"
 
     assert parsed =~
-             "<p style=\"background-color:#fff;color:#000 !important;font-family:Arial, sans-serif;font-size:13px;line-height:22px;margin:0;padding:0;\">"
+             "<p style=\"background-color: #fff; color: #000 !important; font-family: Arial, sans-serif; font-size: 13px; line-height: 22px; margin: 0; padding: 0;\">"
 
     # Ensure that whitespace is maintained when it would affect display
     assert parsed =~ "<span>Test</span> <span>consecutive</span> <span>tags</span>"
@@ -142,13 +142,13 @@ defmodule Premailex.HTMLInlineStylesTest do
 
     assert parsed =~ ~r/(#{Regex.escape("<!--[if !mso]><!-- -->")})|(#{Regex.escape("<!-- [if !mso]><!--  -->")})/
     assert parsed =~
-            "<p style=\"background-color:#000;color:#000 !important;font-family:Arial, sans-serif;font-size:16px;font-weight:bold;line-height:22px;margin:0;padding:0;\">Downlevel-revealed comment</p>"
+            "<p style=\"background-color: #000; color: #000 !important; font-family: Arial, sans-serif; font-size: 16px; font-weight: bold; line-height: 22px; margin: 0; padding: 0;\">Downlevel-revealed comment</p>"
     assert parsed =~ ~r/(#{Regex.escape("<!--<![endif]-->")})|(#{Regex.escape("<!-- <![endif] -->")})/
 
-    assert parsed =~ "<div class=\"match-order-test-1 same-match\" style=\"color:yellow;\">"
-    assert parsed =~ "<div class=\"match-order-test-2 same-match\" style=\"color:yellow;\">"
-    assert parsed =~ "<div class=\"match-order-test-3 same-match\" style=\"color:yellow;\">"
-    assert parsed =~ "<div class=\"match-order-test-4 same-match\" style=\"color:yellow;\">"
+    assert parsed =~ "<div class=\"match-order-test-1 same-match\" style=\"color: yellow;\">"
+    assert parsed =~ "<div class=\"match-order-test-2 same-match\" style=\"color: yellow;\">"
+    assert parsed =~ "<div class=\"match-order-test-3 same-match\" style=\"color: yellow;\">"
+    assert parsed =~ "<div class=\"match-order-test-4 same-match\" style=\"color: yellow;\">"
   end
 
   test "process/3 with css_selector", %{input: input} do
@@ -156,7 +156,7 @@ defmodule Premailex.HTMLInlineStylesTest do
       Premailex.HTMLInlineStyles.process(input, css_selector: "link[rel=\"stylesheet\"][href]")
 
     assert parsed =~
-             "<p style=\"color:#333333;font-family:Arial, sans-serif;font-size:16px;font-weight:bold;line-height:22px;margin:0;padding:0;\">First paragraph"
+             "<p style=\"color: #333333; font-family: Arial, sans-serif; font-size: 16px; font-weight: bold; line-height: 22px; margin: 0; padding: 0;\">First paragraph"
   end
 
   test "process/3 with optimize: :all", %{input: input} do
@@ -198,34 +198,34 @@ defmodule Premailex.HTMLInlineStylesTest do
     html_tree = Premailex.HTMLParser.parse(@input)
     parsed = Premailex.HTMLInlineStyles.process(html_tree)
 
-    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color:black;\">"
+    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color: black;\">"
     assert parsed =~ "<style>"
     assert parsed =~ "<link href"
-    assert parsed =~ "<body style=\"color:#333333;font-family:Arial, sans-serif;font-size:14px;line-height:22px;\">"
+    assert parsed =~ "<body style=\"color: #333333; font-family: Arial, sans-serif; font-size: 14px; line-height: 22px;\">"
 
     parsed = Premailex.HTMLInlineStyles.process(html_tree, [optimize: :all])
 
-    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color:black;\">"
+    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color: black;\">"
     refute parsed =~ "<style>"
     refute parsed =~ "<link href"
-    assert parsed =~ "<body style=\"color:#333333;font-family:Arial, sans-serif;font-size:14px;line-height:22px;\">"
+    assert parsed =~ "<body style=\"color: #333333; font-family: Arial, sans-serif; font-size: 14px; line-height: 22px;\">"
     end
 
   test "process/3 accepts css rule set as second argument" do
     css_rule_set = Premailex.CSSParser.parse("*{color:red;}")
     parsed = Premailex.HTMLInlineStyles.process(@input, css_rule_set)
 
-    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color:red;\">"
+    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color: red;\">"
     assert parsed =~ "<style>"
     assert parsed =~ "<link href"
-    assert parsed =~ "<body style=\"color:red;\">"
+    assert parsed =~ "<body style=\"color: red;\">"
 
     css_rule_set = Premailex.CSSParser.parse("*{color:red;}")
     parsed = Premailex.HTMLInlineStyles.process(@input, css_rule_set, optimize: :all)
 
-    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color:red;\">"
+    assert parsed =~ "<html xmlns=\"http://www.w3.org/1999/xhtml\" style=\"color: red;\">"
     assert parsed =~ "<style>"
     assert parsed =~ "<link href"
-    assert parsed =~ "<body style=\"color:red;\">"
+    assert parsed =~ "<body style=\"color: red;\">"
   end
 end


### PR DESCRIPTION
Gmail strips out inline styles if there isn't spaces [[source](https://stackoverflow.com/a/38041282/1373221)].

This PR adds spaces when converting using the `to_string` method.