### PR TITLE
Add handling for thead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.17 (TBA)
 
 * `Premailex.HTMLInlineStyles.process/3` now warns when styles can't be loaded from URL's
+* `Premailex.HTMLInlineStyles.process/1` now parses `<thead>` and `<tfoot>` elements
 * Require Elixir 1.11
 
 ## v0.3.16 (2022-07-01)

--- a/lib/premailex/html_to_plain_text.ex
+++ b/lib/premailex/html_to_plain_text.ex
@@ -171,6 +171,7 @@ defmodule Premailex.HTMLToPlainText do
 
   defp flatten_table_body(elements), do: Enum.flat_map(elements, &remove_tbody/1)
 
+  defp remove_tbody({"thead", [], table_cells}), do: table_cells
   defp remove_tbody({"tbody", [], table_cells}), do: table_cells
   defp remove_tbody(elem), do: [elem]
 

--- a/lib/premailex/html_to_plain_text.ex
+++ b/lib/premailex/html_to_plain_text.ex
@@ -150,7 +150,7 @@ defmodule Premailex.HTMLToPlainText do
     # Calling tables/1 to make sure all nested tables have been processed
     table_rows
     |> tables()
-    |> flatten_table_body()
+    |> flatten_table_elements()
     |> Util.traverse("tr", &table_rows(&1))
     |> join_binaries("")
   end
@@ -169,11 +169,12 @@ defmodule Premailex.HTMLToPlainText do
     |> Kernel.<>("\n")
   end
 
-  defp flatten_table_body(elements), do: Enum.flat_map(elements, &remove_tbody/1)
+  defp flatten_table_elements(elements), do: Enum.flat_map(elements, &flatten_table_element/1)
 
-  defp remove_tbody({"thead", [], table_cells}), do: table_cells
-  defp remove_tbody({"tbody", [], table_cells}), do: table_cells
-  defp remove_tbody(elem), do: [elem]
+  defp flatten_table_element({"thead", [], table_cells}), do: table_cells
+  defp flatten_table_element({"tbody", [], table_cells}), do: table_cells
+  defp flatten_table_element({"tfoot", [], table_cells}), do: table_cells
+  defp flatten_table_element(elem), do: [elem]
 
   defp wordwrap(text) do
     text

--- a/test/premailex/html_to_plain_text_test.exs
+++ b/test/premailex/html_to_plain_text_test.exs
@@ -41,10 +41,22 @@ defmodule Premailex.HTMLToPlainTextTest do
   <table>
     <thead>
       <tr>
-        <th>Header key in thead</th>
-        <th>Header value in thead</th>
+        <th>thead key</th>
+        <th>thead value</th>
       </tr>
     </thead>
+    <tbody>
+      <tr>
+        <td>tbody key</td>
+        <td>tbody value</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td>tfoot key</td>
+        <td>tfoot value</td>
+      </tr>
+    </tfoot>
     <tr>
       <th>Header key</th>
       <th>Header value</th>
@@ -127,7 +139,9 @@ defmodule Premailex.HTMLToPlainTextTest do
   Paranthesis test
   (http://www.example.com/this-is-a-very-long-uri-to-verify-that-wordwrap-breaks-will-not-break-this-url)
 
-  Header key in thead Header value in thead
+  thead key thead value
+  tbody key tbody value
+  tfoot key tfoot value
   Header key Header value
   Key: Value
   Key 2: Nested key: Value

--- a/test/premailex/html_to_plain_text_test.exs
+++ b/test/premailex/html_to_plain_text_test.exs
@@ -39,6 +39,12 @@ defmodule Premailex.HTMLToPlainTextTest do
   </p>
 
   <table>
+    <thead>
+      <tr>
+        <th>Header key in thead</th>
+        <th>Header value in thead</th>
+      </tr>
+    </thead>
     <tr>
       <th>Header key</th>
       <th>Header value</th>
@@ -121,6 +127,7 @@ defmodule Premailex.HTMLToPlainTextTest do
   Paranthesis test
   (http://www.example.com/this-is-a-very-long-uri-to-verify-that-wordwrap-breaks-will-not-break-this-url)
 
+  Header key in thead Header value in thead
   Header key Header value
   Key: Value
   Key 2: Nested key: Value


### PR DESCRIPTION
I found that cells within `thead` were not making it into the text version, this fixes that.

`remove_tbody` is no longer an accurate function name but I left that you to change if it seems necessary. I added to the test case so that it covers header rows both within and without `thead` but maybe that’s overkill?

Thanks for all the work on this, I’m happy to be able to remove a clunky call out to Ruby from an old application 🎉