### PR TITLE
Ignore escaped commas when splitting selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `Premailex.HTMLInlineStyles.process/3` now warns when styles can't be loaded from URL's
 * `Premailex.HTMLInlineStyles.process/1` now parses `<thead>` and `<tfoot>` elements
+* `Premailex.CSSParser.parse/1` now handles escaped commas
 * Require Elixir 1.11
 
 ## v0.3.16 (2022-07-01)

--- a/lib/premailex/css_parser.ex
+++ b/lib/premailex/css_parser.ex
@@ -62,7 +62,8 @@ defmodule Premailex.CSSParser do
 
   defp parse_selectors_rules([_, selector, rules]) do
     selector
-    |> String.split(",")
+    # Ignore escaped commas
+    |> String.split(~r/(?<!\\),/)
     |> Enum.map(&parse_selector_rules(&1, rules))
   end
 

--- a/test/premailex/css_parser_test.exs
+++ b/test/premailex/css_parser_test.exs
@@ -18,6 +18,7 @@ defmodule Premailex.CSSParserTest do
     src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
          url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
   }
+  .with\\,escaped\\,commas {}
   """
 
   @parsed [
@@ -54,6 +55,11 @@ defmodule Premailex.CSSParserTest do
       ],
       selector: "div p > a:hover",
       specificity: 4
+    },
+    %{
+      rules: [],
+      selector: ".with\\,escaped\\,commas",
+      specificity: 1
     }
   ]
 


### PR DESCRIPTION
Fixes #76.