### PR TITLE
tbody with class does not make it to output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.18 (TBA)
+
+* Fixed bug in `Premailex.HTMLToPlainText.parse/3` with `<thread>`, `<tbody>`, `<tfoot>` being excluded if the HTML element had any attributes
+
 ## v0.3.17 (2023-02-21)
 
 * `Premailex.HTMLInlineStyles.process/3` now warns when styles can't be loaded from URL's

--- a/lib/premailex/html_to_plain_text.ex
+++ b/lib/premailex/html_to_plain_text.ex
@@ -171,9 +171,9 @@ defmodule Premailex.HTMLToPlainText do
 
   defp flatten_table_elements(elements), do: Enum.flat_map(elements, &flatten_table_element/1)
 
-  defp flatten_table_element({"thead", [], table_cells}), do: table_cells
-  defp flatten_table_element({"tbody", [], table_cells}), do: table_cells
-  defp flatten_table_element({"tfoot", [], table_cells}), do: table_cells
+  defp flatten_table_element({"thead", _, table_cells}), do: table_cells
+  defp flatten_table_element({"tbody", _, table_cells}), do: table_cells
+  defp flatten_table_element({"tfoot", _, table_cells}), do: table_cells
   defp flatten_table_element(elem), do: [elem]
 
   defp wordwrap(text) do

--- a/test/premailex/html_to_plain_text_test.exs
+++ b/test/premailex/html_to_plain_text_test.exs
@@ -45,7 +45,7 @@ defmodule Premailex.HTMLToPlainTextTest do
         <th>thead value</th>
       </tr>
     </thead>
-    <tbody class="a-class">
+    <tbody>
       <tr>
         <td>tbody key</td>
         <td>tbody value</td>
@@ -152,4 +152,23 @@ defmodule Premailex.HTMLToPlainTextTest do
   test "process/1" do
     assert Premailex.HTMLToPlainText.process(@input) == String.trim(@parsed)
   end
+
+  test "process/1 with attributes" do
+    assert Premailex.HTMLToPlainText.process(add_attributes(@input)) == String.trim(@parsed)
+  end
+
+  defp add_attributes(html) do
+    html
+    |> Premailex.HTMLParser.parse()
+    |> add_attribute("data-attribute", "value")
+    |> Premailex.HTMLParser.to_string()
+  end
+
+  defp add_attribute(elements, key, value) when is_list(elements) do
+    Enum.map(elements, &add_attribute(&1, key, value))
+  end
+  defp add_attribute({tag, attrs, children}, key, value) do
+    {tag, attrs ++ [{key, value}], add_attribute(children, key, value)}
+  end
+  defp add_attribute(other, _key, _value), do: other
 end

--- a/test/premailex/html_to_plain_text_test.exs
+++ b/test/premailex/html_to_plain_text_test.exs
@@ -45,7 +45,7 @@ defmodule Premailex.HTMLToPlainTextTest do
         <th>thead value</th>
       </tr>
     </thead>
-    <tbody>
+    <tbody class="a-class">
       <tr>
         <td>tbody key</td>
         <td>tbody value</td>


### PR DESCRIPTION
This amends the existing test to show that a `tbody` with a `class` attribute is not part of the final output. I didn’t immediately see what might be needed to get this working but I’ll look at it more in the future 🤞🏻