### PR TITLE
Add stripping of @charset lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.19 (TBA)
+
+* Ignore `@charset` CSS at-rule
+
 ## v0.3.18 (2023-04-07)
 
 * Fixed bug in `Premailex.HTMLToPlainText.parse/3` with `<thread>`, `<tbody>`, `<tfoot>` being excluded if the HTML element had any attributes

--- a/lib/premailex/css_parser.ex
+++ b/lib/premailex/css_parser.ex
@@ -37,6 +37,7 @@ defmodule Premailex.CSSParser do
   )/ix
   @comments ~r/\/\*[\s\S]*?\*\//m
   @media_queries ~r/@media[^{]+{([\s\S]+?})\s*}/mi
+  @charset_rules ~r/^\s*@charset .*;$/mi
   @font_face ~r/@font-face\s*{[\s\S]+?}/mi
 
   @doc """
@@ -123,6 +124,7 @@ defmodule Premailex.CSSParser do
     string
     |> String.replace(@font_face, "")
     |> String.replace(@media_queries, "")
+    |> String.replace(@charset_rules, "")
     |> String.replace(@comments, "")
   end
 

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -5,6 +5,8 @@ defmodule Premailex.HTMLInlineStylesTest do
   alias ExUnit.CaptureLog
 
   @css_link_content """
+  @charset "utf-8";
+
   html {color:black;}
   body,table,p,td,ul,ol {color:#333333; font-family:Arial, sans-serif; font-size:14px; line-height:22px;}
 


### PR DESCRIPTION
My asset pipeline changed a bit and the generated CSS was updated to start with this:
```
@charset "UTF-8";
```

This caused Premailex to crash when inlining styles, like you can see [here](https://github.com/backspace/premailex/actions/runs/6923210067/job/18830841434#step:6:439):

```
     ** (FunctionClauseError) no function clause matching in Floki.Selector.Parser.do_parse/2
```

I was able to work around it by adding a [Webpack plugin](https://github.com/backspace/adventures/commit/662943f733588b1120b5b822699a98dd7c940b4e#diff-53dc935883f9b00106989705ac8e4abc2f981d3199cb333131f66a6fb0eb6a02) to strip the `@charset` line from the CSS, but I figured this might happen to others so here’s a draft fix. 

It seems hackish, though maybe unavoidable considering #30? I’m also unsure why `@keyframes` and the like wouldn’t cause similar problems.