### PR TITLE
Fix a deprecation log from Floki

### DIFF
--- a/lib/premailex/html_parser/floki.ex
+++ b/lib/premailex/html_parser/floki.ex
@@ -49,6 +49,13 @@ defmodule Premailex.HTMLParser.Floki do
 
   @impl true
   @doc false
+  def text(tree) when is_binary(tree) do
+    case Floki.parse_document(tree) do
+      {:ok, document} -> Floki.text(document)
+      error -> error
+    end
+  end
+
   def text(tree), do: Floki.text(tree)
 
   # """


### PR DESCRIPTION
Floki will write `info` log when if a `binary` is passed to `Floki.text()` - which is deprecated. This PR fixes it