### PR TITLE
feat: pass to_inline_css options through to parse

### DIFF
--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -25,7 +25,7 @@ defmodule Premailex.HTMLInlineStyles do
 
   def process(html, css_rule_sets_or_options, options) when is_binary(html) do
     html
-    |> HTMLParser.parse()
+    |> HTMLParser.parse(options)
     |> process(css_rule_sets_or_options, options)
   end
 

--- a/lib/premailex/html_parser.ex
+++ b/lib/premailex/html_parser.ex
@@ -8,7 +8,7 @@ defmodule Premailex.HTMLParser do
   @type html_tree :: tuple() | list()
   @type selector :: binary()
 
-  @callback parse(binary()) :: html_tree()
+  @callback parse(binary(), Keyword.t()) :: html_tree()
   @callback all(html_tree(), selector()) :: [html_tree()]
   @callback filter(html_tree(), selector()) :: [html_tree()]
   @callback to_string(html_tree()) :: binary()
@@ -22,8 +22,8 @@ defmodule Premailex.HTMLParser do
       iex> Premailex.HTMLParser.parse("<html><head></head><body><h1>Title</h1></body></html>")
       {"html", [], [{"head", [], []}, {"body", [], [{"h1", [], ["Title"]}]}]}
   """
-  @spec parse(binary()) :: html_tree()
-  def parse(html), do: parser().parse(html)
+  @spec parse(binary(), Keyword.t()) :: html_tree()
+  def parse(html, options \\ []), do: parser().parse(html, options)
 
   @doc """
   Searches an HTML tree for the selector.


### PR DESCRIPTION
### Description

Passes options from `to_inline_css` through to `HTMLParser.parse/2` so that we can pass context through to the parser and feature flag using the new HTML parser.