### PR TITLE
Fix Dialyzer typing for to_inline_css options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Requires Elixir 1.14 or higher.
 
 * Fixed compiler warnings in `Premailex.HTMLParser.Meeseeks`
+* Fixed invalid spec in `Premailex.HTMLInlineStyles.process/3`
 
 ## v0.3.20 (2025-01-20)
 

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -7,7 +7,7 @@ defmodule Premailex.HTMLInlineStyles do
   alias Premailex.{CSSParser, HTMLParser, Util}
 
   @type html_or_html_tree() :: String.t() | HTMLParser.html_tree()
-  @type css_rule_sets() :: [CSSParser.rule_set()]
+  @type css_rule_sets_or_options() :: [CSSParser.rule_set()] | keyword()
 
   @doc """
   Processes an HTML string adding inline styles.
@@ -19,10 +19,8 @@ defmodule Premailex.HTMLInlineStyles do
       * `:all` - apply all optimization steps
       * `:remove_style_tags` - Remove style tags (can be combined in a list)
   """
-  @spec process(html_or_html_tree()) :: String.t()
-  @spec process(html_or_html_tree(), css_rule_sets() | keyword() | nil) :: String.t()
-  @spec process(html_or_html_tree(), keyword(), nil) :: String.t()
-  @spec process(html_or_html_tree(), css_rule_sets() | nil, keyword() | nil) :: String.t()
+  @spec process(html_or_html_tree(), css_rule_sets_or_options() | nil, keyword() | nil) ::
+          String.t()
   def process(html_or_html_tree, css_rule_sets_or_options \\ nil, options \\ nil)
 
   def process(html, css_rule_sets_or_options, options) when is_binary(html) do

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -6,6 +6,9 @@ defmodule Premailex.HTMLInlineStyles do
 
   alias Premailex.{CSSParser, HTMLParser, Util}
 
+  @type html_or_html_tree() :: String.t() | HTMLParser.html_tree()
+  @type css_rule_sets() :: [CSSParser.rule_set()]
+
   @doc """
   Processes an HTML string adding inline styles.
 
@@ -16,11 +19,10 @@ defmodule Premailex.HTMLInlineStyles do
       * `:all` - apply all optimization steps
       * `:remove_style_tags` - Remove style tags (can be combined in a list)
   """
-  @spec process(
-          String.t() | HTMLParser.html_tree(),
-          [CSSParser.rule_set()] | nil,
-          Keyword.t() | nil
-        ) :: String.t()
+  @spec process(html_or_html_tree()) :: String.t()
+  @spec process(html_or_html_tree(), css_rule_sets() | keyword() | nil) :: String.t()
+  @spec process(html_or_html_tree(), keyword(), nil) :: String.t()
+  @spec process(html_or_html_tree(), css_rule_sets() | nil, keyword() | nil) :: String.t()
   def process(html_or_html_tree, css_rule_sets_or_options \\ nil, options \\ nil)
 
   def process(html, css_rule_sets_or_options, options) when is_binary(html) do


### PR DESCRIPTION
I tried to specify the `css_selector` option in `Premailex.to_inline_css` and Dialyzer complained:
```
lib/project/mailer.ex:17:22:call
The function call will not succeed.

Premailex.to_inline_css(binary(), [
  {:css_selector, binary()}
])

will never return since the 2nd arguments differ
from the success typing arguments:

(binary(), nil | [%{:rules => [map()], :selector => binary(), :specificity => number()}]) ::
  :ok
def a() do
  :ok
end
```

This patch improves the spec for `Premailex.HTMLInlineStyles.process` to allow the second argument to be either a list of CSS Parser rule sets or a keyword list, which matches the implementation.