### PR TITLE
Refactor CSS parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Requires Elixir 1.14 or higher.
 * `Floki` is now optional
 * Added support for `LazyHTML`
 * Added `Premailex.CSSParser.split_selector_groups/1` for selector group splitting
-* `Premailex.CSSParser.parse_rules/1` now does case insensitive, terminal `!important` detection
+* `Premailex.CSSParser` rewritten and no longer uses regular expression to parse CSS
+* Renamed `Premailex.CSSParser.parse_rules/1` to `Premailex.CSSParser.parse_declaration_block/1`
+* `Premailex.CSSParser.parse_declaration_block/1` now does case insensitive, terminal `!important` detection
 
 ## v0.3.20 (2025-01-20)
 

--- a/lib/premailex/css_parser.ex
+++ b/lib/premailex/css_parser.ex
@@ -2,76 +2,176 @@ defmodule Premailex.CSSParser do
   @moduledoc """
   CSS parser used by Premailex.
 
-  ## Known limitations
+  ## Limitations
 
-  The CSSParser is mostly naive and doesn't handle all edge cases such as
-  `content: "a;b"` rules. The CSS specificity calculation is regex-based and
-  intended for practical inlining precedence, not full Selectors Level 4
-  correctness.
+    * At-rules (`@media`, `@font-face`, `@import`, etc.) and comments are
+      stripped;
+
+    * Specificity for `:not(...)`, `:is(...)`, `:where(...)` is approximated
+      as a single pseudo-class, though Selectors Level 4 needs the specificity
+      inherited from their argument (or `0` for `:where`);
   """
+  require Logger
 
-  @type rule :: %{directive: String.t(), value: String.t(), important?: boolean}
-  @type rule_set :: %{rules: [rule], selector: String.t(), specificity: number}
+  @typedoc "A CSS rule declaration."
+  @type declaration :: %{property: String.t(), value: String.t(), important?: boolean()}
 
-  @css_selector_rules ~r/([\s\S]*?){([\s\S]*?)}/mi
+  @typedoc "A CSS rule with computed specificity."
+  @type rule :: %{declarations: [declaration()], selector: String.t(), specificity: specificity()}
 
-  @non_id_attributes_and_pseudo_classes ~r/
-    (\.[\w]+)                     # classes
-    |
-    \[(\w+)                       # attributes
-    |
-    (\:(                          # pseudo classes
-      link|visited|active
-      |hover|focus
-      |lang
-      |target
-      |enabled|disabled|checked|indeterminate
-      |root
-      |nth-child|nth-last-child|nth-of-type|nth-last-of-type
-      |first-child|last-child|first-of-type|last-of-type
-      |only-child|only-of-type
-      |empty|contains
-    ))
-  /ix
-  @elements_and_pseudo_elements ~r/
-    ((^|[\s\+\>\~]+)[\w]+       # elements
-    |
-    \:{1,2}(                    # pseudo-elements
-      after|before
-      |first-letter|first-line
-      |selection
-    )
-  )/ix
-  @comments ~r/\/\*[\s\S]*?\*\//m
-  @media_queries ~r/@media[^{]+{([\s\S]+?})\s*}/mi
-  @charset_rules ~r/^\s*@charset .*;$/mi
-  @font_face ~r/@font-face\s*{[\s\S]+?}/mi
+  @typedoc "A CSS pseudo-class or pseudo-element."
+  @type pseudo :: %{
+          name: String.t(),
+          expression: String.t() | nil,
+          kind: :pseudo_class | :pseudo_element
+        }
+
+  @typedoc """
+  A single element step in a selector.
+  """
+  @type selector_group_step :: %{
+          tag: String.t() | nil,
+          id: String.t() | nil,
+          classes: [String.t()],
+          attrs: [String.t() | {String.t(), String.t()}],
+          pseudos: [pseudo()],
+          combinator: :descendant | :child | :adjacent | :sibling | :column | nil
+        }
+
+  @typedoc "A list of selector steps, ordered right to left."
+  @type selector_group :: [selector_group_step()]
+
+  @typedoc """
+  CSS specificity, matching the Selectors Level 4 4-tuple model.
+
+  Structured as `{inline?, ids, classes, elements}`:
+
+    * `inline?` — If it's an inlined style;
+    * `ids` — count of ID selectors;
+    * `classes` — count of class, attribute, and pseudo-class selectors;
+    * `elements` — count of tag and pseudo-element selectors;
+  """
+  @type specificity :: {0..1, non_neg_integer(), non_neg_integer(), non_neg_integer()}
+
+  @selector_whitespace [?\s, ?\t, ?\n, ?\r, ?\f]
+  @step %{tag: nil, id: nil, classes: [], attrs: [], pseudos: [], combinator: nil}
+
+  @initial_selector_state %{
+    type: :tag,
+    step: @step,
+    buffer: "",
+    pending_relation: nil,
+    bracket_depth: 0,
+    paren_depth: 0,
+    quote_char: nil,
+    steps: []
+  }
 
   @doc """
   Parses a CSS string into a map.
 
+  Ignores all at-rules (e.g. `@media`, `@font-face`, etc.) and comments, as
+  these are not relevant for inlining CSS.
+
   ## Examples
 
       iex> Premailex.CSSParser.parse("body { background-color: #fff !important; color: red; }")
-      [%{rules: [%{directive: "background-color", value: "#fff !important", important?: true},
-                 %{directive: "color", value: "red", important?: false}],
-         selector: "body",
-         specificity: 1}]
+      [
+        %{
+          declarations: [
+            %{property: "background-color", value: "#fff !important", important?: true},
+            %{property: "color", value: "red", important?: false}
+          ],
+          selector: "body",
+          specificity: {0, 0, 0, 1}
+        }
+      ]
   """
-  @spec parse(String.t()) :: [rule_set]
-  def parse(""), do: []
+  @spec parse(String.t()) :: [rule()]
+  def parse(css), do: parse(css, "", "", 0, [])
 
-  def parse(css) do
-    @css_selector_rules
-    |> Regex.scan(strip(css))
-    |> Enum.map(&parse_selectors_rules(&1))
-    |> Enum.reduce([], &Enum.concat(&2, &1))
+  defp parse(<<>>, _selector, _declaration_block, _depth, acc), do: Enum.reverse(acc)
+
+  defp parse(<<"/*", rest::binary>>, selector, declaration_block, depth, acc) do
+    case :binary.split(rest, "*/") do
+      [_comment, rest] -> parse(rest, selector, declaration_block, depth, acc)
+      [_unterminated] -> Enum.reverse(acc)
+    end
   end
 
-  defp parse_selectors_rules([_, selector, rules]) do
+  defp parse(<<"@", rest::binary>>, "", _declaration_block, 0, acc) do
+    rest
+    |> remove_at_rule(0)
+    |> parse("", "", 0, acc)
+  end
+
+  defp parse(<<c, rest::binary>>, "", _declaration_block, 0, acc) when c in @selector_whitespace,
+    do: parse(rest, "", "", 0, acc)
+
+  defp parse(<<"{", rest::binary>>, selector, _declaration_block, 0, acc),
+    do: parse(rest, selector, "", 1, acc)
+
+  defp parse(<<"{", rest::binary>>, selector, declaration_block, depth, acc),
+    do: parse(rest, selector, <<declaration_block::binary, "{">>, depth + 1, acc)
+
+  defp parse(<<"}", rest::binary>>, selector, declaration_block, 1, acc) do
+    parsed_declarations = parse_declaration_block(declaration_block)
+
     selector
     |> split_selector_groups()
-    |> Enum.map(&parse_selector_rules(&1, rules))
+    |> Enum.reduce(acc, fn group, acc ->
+      [build_rule(group, parsed_declarations) | acc]
+    end)
+    |> then(&parse(rest, "", "", 0, &1))
+  end
+
+  defp parse(<<"}", rest::binary>>, selector, declaration_block, depth, acc),
+    do: parse(rest, selector, <<declaration_block::binary, "}">>, depth - 1, acc)
+
+  defp parse(<<char, rest::binary>>, selector, _declaration_block, 0, acc),
+    do: parse(rest, <<selector::binary, char>>, "", 0, acc)
+
+  defp parse(<<char, rest::binary>>, selector, declaration_block, depth, acc),
+    do: parse(rest, selector, <<declaration_block::binary, char>>, depth, acc)
+
+  defp remove_at_rule(input, depth), do: remove_at_rule(input, depth, nil)
+
+  defp remove_at_rule(<<>>, _depth, _quote_char), do: ""
+
+  defp remove_at_rule(<<quote_char, rest::binary>>, depth, nil) when quote_char in [?", ?'],
+    do: remove_at_rule(rest, depth, quote_char)
+
+  defp remove_at_rule(<<"\\", quote_char, rest::binary>>, depth, quote_char)
+       when quote_char in [?", ?'],
+       do: remove_at_rule(rest, depth, quote_char)
+
+  defp remove_at_rule(<<quote_char, rest::binary>>, depth, quote_char),
+    do: remove_at_rule(rest, depth, nil)
+
+  defp remove_at_rule(<<";", rest::binary>>, 0, nil), do: rest
+  defp remove_at_rule(<<"{", rest::binary>>, depth, nil), do: remove_at_rule(rest, depth + 1, nil)
+  defp remove_at_rule(<<"}", rest::binary>>, depth, nil) when depth <= 1, do: rest
+  defp remove_at_rule(<<"}", rest::binary>>, depth, nil), do: remove_at_rule(rest, depth - 1, nil)
+  defp remove_at_rule(<<_, rest::binary>>, depth, nil), do: remove_at_rule(rest, depth, nil)
+
+  defp remove_at_rule(<<_, rest::binary>>, depth, quote_char),
+    do: remove_at_rule(rest, depth, quote_char)
+
+  defp build_rule(group, declarations) do
+    specificity =
+      group
+      |> parse_selector_group()
+      |> Enum.reduce({0, 0, 0, 0}, fn step, {a, b, c, d} ->
+        ids = (step.id && 1) || 0
+        pseudo_classes = Enum.count(step.pseudos, &(&1.kind == :pseudo_class))
+        classes = length(step.classes) + length(step.attrs) + pseudo_classes
+        pseudo_elements = Enum.count(step.pseudos, &(&1.kind == :pseudo_element))
+        elements = ((step.tag && step.tag != "*" && 1) || 0) + pseudo_elements
+
+        {a, b + ids, c + classes, d + elements}
+      end)
+
+    %{selector: group, declarations: declarations, specificity: specificity}
   end
 
   @doc """
@@ -291,70 +391,550 @@ defmodule Premailex.CSSParser do
     end
   end
 
-  defp parse_selector_rules(selector, rules) do
-    %{
-      selector: selector,
-      rules: parse_rules(rules),
-      specificity: calculate_specificity(selector)
-    }
-  end
-
   @doc """
-  Parses a CSS rules string into a map.
+  Parses a selector string into a list of selector groups.
 
-  Note: `parse_rules/1` won't strip any CSS comments unlike `parse/1`.
+  The selector groups are represented as lists of steps, where each step is a
+  map containing the tag, id, classes, attributes, pseudo-classes/elements, and
+  combinator for that step. The steps are ordered from right to left.
+
+  Selectors that fail to parse are dropped with a debug log.
 
   ## Examples
 
-      iex> Premailex.CSSParser.parse_rules("background-color: #fff; color: red;")
-      [%{directive: "background-color", value: "#fff", important?: false},
-       %{directive: "color", value: "red", important?: false}]
+      iex> Premailex.CSSParser.parse_selector_groups("div.foo")
+      [[%{tag: "div", id: nil, classes: ["foo"], attrs: [], pseudos: [], combinator: nil}]]
+
+      iex> Premailex.CSSParser.parse_selector_groups("body > p")
+      [
+        [
+          %{tag: "p", id: nil, classes: [], attrs: [], pseudos: [], combinator: nil},
+          %{tag: "body", id: nil, classes: [], attrs: [], pseudos: [], combinator: :child}
+        ]
+      ]
   """
-  @spec parse_rules(String.t()) :: [rule]
-  def parse_rules(rules) do
-    rules
-    |> String.split(";")
-    |> Enum.map(&parse_rule(&1))
-    |> Enum.filter(&(!is_nil(&1)))
+  @spec parse_selector_groups(String.t()) :: [selector_group()]
+  def parse_selector_groups(selector) do
+    selector
+    |> split_selector_groups()
+    |> Enum.map(&parse_selector_group/1)
   end
 
-  defp parse_rule(rule) when is_binary(rule) do
-    rule
-    |> String.trim()
-    |> String.split(":", parts: 2)
-    |> parse_rule()
+  defp parse_selector_group(selector_group) do
+    case parse_selector_steps(selector_group, @initial_selector_state) do
+      {:ok, steps, nil} ->
+        steps
+
+      _invalid ->
+        Logger.debug(fn -> "Invalid selector group \"#{selector_group}\". Ignoring." end)
+
+        []
+    end
   end
 
-  defp parse_rule([directive, value]) do
-    %{
-      directive: String.trim(directive),
-      value: String.trim(value),
-      important?: important?(value)
+  defp parse_selector_steps(<<>>, %{bracket_depth: bd, paren_depth: pd}) when bd > 0 or pd > 0,
+    do: :error
+
+  defp parse_selector_steps(<<>>, %{bracket_depth: 0, paren_depth: 0} = state) do
+    case update_selector_step(state.type, state.step, state.buffer) do
+      {:ok, step} -> flush_selector_step(step, state.pending_relation, state.steps)
+      :error -> :error
+    end
+  end
+
+  defp parse_selector_steps(
+         <<"#", rest::binary>>,
+         %{bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       ),
+       do: update_step_and_set_type(rest, state, :id)
+
+  defp parse_selector_steps(
+         <<".", rest::binary>>,
+         %{bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       ),
+       do: update_step_and_set_type(rest, state, :class)
+
+  defp parse_selector_steps(
+         <<":", rest::binary>>,
+         %{type: :pseudo_class, buffer: "", bracket_depth: 0, paren_depth: 0, quote_char: nil} =
+           state
+       ),
+       do: parse_selector_steps(rest, %{state | type: :pseudo_element})
+
+  defp parse_selector_steps(
+         <<":", rest::binary>>,
+         %{type: _any, bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       ),
+       do: update_step_and_set_type(rest, state, :pseudo_class)
+
+  defp parse_selector_steps(<<quote_char, rest::binary>>, %{quote_char: nil} = state)
+       when quote_char in [?", ?'] do
+    parse_selector_steps(rest, %{
+      state
+      | buffer: <<state.buffer::binary, quote_char>>,
+        quote_char: quote_char
+    })
+  end
+
+  defp parse_selector_steps(
+         <<"\\", quote_char, rest::binary>>,
+         %{quote_char: quote_char} = state
+       )
+       when quote_char in [?", ?'] do
+    parse_selector_steps(rest, %{state | buffer: <<state.buffer::binary, "\\", quote_char>>})
+  end
+
+  defp parse_selector_steps(<<quote_char, rest::binary>>, %{quote_char: quote_char} = state)
+       when quote_char in [?", ?'] do
+    parse_selector_steps(rest, %{
+      state
+      | buffer: <<state.buffer::binary, quote_char>>,
+        quote_char: nil
+    })
+  end
+
+  defp parse_selector_steps(
+         <<char, rest::binary>>,
+         %{bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       )
+       when char in @selector_whitespace do
+    case update_selector_step(state.type, state.step, state.buffer) do
+      {:ok, step} ->
+        {:ok, next_steps, next_pending} =
+          flush_selector_step(step, state.pending_relation, state.steps)
+
+        parse_selector_steps(rest, %{
+          @initial_selector_state
+          | pending_relation: next_pending,
+            steps: next_steps
+        })
+
+      :error ->
+        :error
+    end
+  end
+
+  defp parse_selector_steps(
+         <<"||", rest::binary>>,
+         %{bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       ) do
+    flush_step_and_set_relation(rest, state, :column)
+  end
+
+  defp parse_selector_steps(
+         <<">", rest::binary>>,
+         %{bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       ) do
+    flush_step_and_set_relation(rest, state, :child)
+  end
+
+  defp parse_selector_steps(
+         <<"+", rest::binary>>,
+         %{bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       ) do
+    flush_step_and_set_relation(rest, state, :adjacent)
+  end
+
+  defp parse_selector_steps(
+         <<"~", rest::binary>>,
+         %{bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       ) do
+    flush_step_and_set_relation(rest, state, :sibling)
+  end
+
+  defp parse_selector_steps(
+         <<"[", rest::binary>>,
+         %{bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       ) do
+    case update_selector_step(state.type, state.step, state.buffer) do
+      {:ok, step} ->
+        parse_selector_steps(rest, %{
+          state
+          | type: :attribute,
+            step: step,
+            buffer: "",
+            bracket_depth: 1
+        })
+
+      :error ->
+        :error
+    end
+  end
+
+  defp parse_selector_steps(
+         <<"]", rest::binary>>,
+         %{type: :attribute, bracket_depth: 1, quote_char: nil} = state
+       ) do
+    case update_selector_step(:attribute, state.step, state.buffer) do
+      {:ok, step} ->
+        parse_selector_steps(rest, %{
+          state
+          | type: :tag,
+            step: step,
+            buffer: "",
+            bracket_depth: 0
+        })
+
+      :error ->
+        :error
+    end
+  end
+
+  defp parse_selector_steps(<<"[", _rest::binary>>, %{paren_depth: 0, quote_char: nil}),
+    do: :error
+
+  defp parse_selector_steps(<<"]", _rest::binary>>, %{paren_depth: 0, quote_char: nil}),
+    do: :error
+
+  defp parse_selector_steps(<<"(", _rest::binary>>, %{
+         type: kind,
+         buffer: "",
+         bracket_depth: 0,
+         paren_depth: 0,
+         quote_char: nil
+       })
+       when kind in [:pseudo_class, :pseudo_element],
+       do: :error
+
+  defp parse_selector_steps(
+         <<"(", rest::binary>>,
+         %{type: kind, bracket_depth: 0, paren_depth: 0, quote_char: nil} = state
+       )
+       when kind in [:pseudo_class, :pseudo_element] do
+    parse_selector_steps(rest, %{
+      state
+      | type: {kind, state.buffer},
+        buffer: "",
+        paren_depth: 1
+    })
+  end
+
+  defp parse_selector_steps(
+         <<")", rest::binary>>,
+         %{type: {kind, name}, bracket_depth: 0, paren_depth: 1, quote_char: nil} = state
+       )
+       when kind in [:pseudo_class, :pseudo_element] do
+    pseudo = %{name: name, expression: state.buffer, kind: kind}
+    step = %{state.step | pseudos: [pseudo | state.step.pseudos]}
+
+    parse_selector_steps(rest, %{state | type: :tag, step: step, buffer: "", paren_depth: 0})
+  end
+
+  defp parse_selector_steps(<<"(", rest::binary>>, %{paren_depth: pd, quote_char: nil} = state)
+       when pd > 0 do
+    parse_selector_steps(rest, %{
+      state
+      | buffer: <<state.buffer::binary, "(">>,
+        paren_depth: pd + 1
+    })
+  end
+
+  defp parse_selector_steps(<<")", rest::binary>>, %{paren_depth: pd, quote_char: nil} = state)
+       when pd > 0 do
+    parse_selector_steps(rest, %{
+      state
+      | buffer: <<state.buffer::binary, ")">>,
+        paren_depth: pd - 1
+    })
+  end
+
+  defp parse_selector_steps(<<"(", _rest::binary>>, %{quote_char: nil}), do: :error
+  defp parse_selector_steps(<<")", _rest::binary>>, %{quote_char: nil}), do: :error
+
+  defp parse_selector_steps(<<char, rest::binary>>, state) do
+    parse_selector_steps(rest, %{state | buffer: <<state.buffer::binary, char>>})
+  end
+
+  defp update_selector_step(:tag, step, ""), do: {:ok, step}
+  defp update_selector_step(:tag, step, buffer), do: {:ok, %{step | tag: buffer}}
+
+  defp update_selector_step(:id, _step, ""), do: :error
+  defp update_selector_step(:id, step, buffer), do: {:ok, %{step | id: buffer}}
+
+  defp update_selector_step(:class, _step, ""), do: :error
+
+  defp update_selector_step(:class, step, buffer),
+    do: {:ok, %{step | classes: [buffer | step.classes]}}
+
+  defp update_selector_step(:attribute, step, buffer) do
+    case parse_attribute_selector(buffer, "") do
+      {:ok, attr} -> {:ok, %{step | attrs: [attr | step.attrs]}}
+      :error -> :error
+    end
+  end
+
+  defp update_selector_step(:pseudo_class, _step, ""), do: :error
+
+  defp update_selector_step(:pseudo_class, step, name),
+    do:
+      {:ok,
+       %{
+         step
+         | pseudos: [%{name: name, expression: nil, kind: :pseudo_class} | step.pseudos]
+       }}
+
+  defp update_selector_step(:pseudo_element, _step, ""), do: :error
+
+  defp update_selector_step(:pseudo_element, step, name),
+    do:
+      {:ok,
+       %{
+         step
+         | pseudos: [%{name: name, expression: nil, kind: :pseudo_element} | step.pseudos]
+       }}
+
+  defp flush_selector_step(@step, pending_relation, steps), do: {:ok, steps, pending_relation}
+
+  defp flush_selector_step(step, pending_relation, steps) do
+    step = %{
+      step
+      | classes: Enum.reverse(step.classes),
+        attrs: Enum.reverse(step.attrs),
+        pseudos: Enum.reverse(step.pseudos)
     }
+
+    do_flush_selector_step(step, steps, pending_relation)
   end
 
-  defp parse_rule([""]), do: nil
+  defp do_flush_selector_step(step, [], nil), do: {:ok, [step], nil}
 
-  defp parse_rule([value]) do
-    %{
-      directive: "",
-      value: String.trim(value),
-      important?: important?(value)
-    }
+  defp do_flush_selector_step(step, [previous_step | previous_steps], pending_relation) do
+    previous_step = %{previous_step | combinator: pending_relation || :descendant}
+
+    {:ok, [step, previous_step | previous_steps], nil}
   end
 
-  defp important?(value) when is_binary(value) do
-    value
-    |> String.trim()
-    |> String.match?(~r/!important\s*$/i)
+  defp flush_step_and_set_relation(rest, state, relation) do
+    case update_selector_step(state.type, state.step, state.buffer) do
+      {:ok, step} ->
+        case flush_selector_step(step, state.pending_relation, state.steps) do
+          {:ok, [], _} ->
+            :error
+
+          {:ok, final_steps, nil} ->
+            parse_selector_steps(rest, %{
+              @initial_selector_state
+              | pending_relation: relation,
+                steps: final_steps
+            })
+
+          {:ok, _, _} ->
+            :error
+        end
+
+      :error ->
+        :error
+    end
   end
 
-  defp strip(string) do
-    string
-    |> String.replace(@font_face, "")
-    |> String.replace(@media_queries, "")
-    |> String.replace(@charset_rules, "")
-    |> String.replace(@comments, "")
+  defp update_step_and_set_type(rest, state, type) do
+    case update_selector_step(state.type, state.step, state.buffer) do
+      {:ok, step} ->
+        parse_selector_steps(rest, %{state | type: type, step: step, buffer: ""})
+
+      :error ->
+        :error
+    end
+  end
+
+  defp parse_attribute_selector(<<>>, ""), do: :error
+  defp parse_attribute_selector(<<>>, name), do: {:ok, name}
+
+  defp parse_attribute_selector(<<char, rest::binary>>, "") when char in @selector_whitespace,
+    do: parse_attribute_selector(rest, "")
+
+  defp parse_attribute_selector(<<char, rest::binary>>, name) when char in @selector_whitespace do
+    case String.trim_leading(rest) do
+      "" -> {:ok, name}
+      <<"=", rest::binary>> -> parse_attribute_selector(rest, name, "")
+      _ -> :error
+    end
+  end
+
+  defp parse_attribute_selector(<<"=", rest::binary>>, name),
+    do: parse_attribute_selector(rest, name, "")
+
+  defp parse_attribute_selector(<<char, rest::binary>>, name),
+    do: parse_attribute_selector(rest, <<name::binary, char>>)
+
+  defp parse_attribute_selector(<<>>, name, value), do: {:ok, {name, value}}
+
+  defp parse_attribute_selector(<<char, rest::binary>>, name, "")
+       when char in @selector_whitespace,
+       do: parse_attribute_selector(rest, name, "")
+
+  defp parse_attribute_selector(<<quote_char, rest::binary>>, name, "")
+       when quote_char in [?", ?'],
+       do: parse_attribute_selector(rest, name, "", quote_char)
+
+  defp parse_attribute_selector(<<char, _::binary>>, _name, _value) when char in [?", ?'],
+    do: :error
+
+  defp parse_attribute_selector(<<char, rest::binary>>, name, value)
+       when char in @selector_whitespace do
+    case String.trim_leading(rest) do
+      "" -> {:ok, {name, value}}
+      _ -> :error
+    end
+  end
+
+  defp parse_attribute_selector(<<char, rest::binary>>, name, value),
+    do: parse_attribute_selector(rest, name, <<value::binary, char>>)
+
+  defp parse_attribute_selector(<<>>, _name, _value, _quote_char), do: :error
+
+  defp parse_attribute_selector(<<"\\", quote_char, rest::binary>>, name, value, quote_char),
+    do: parse_attribute_selector(rest, name, <<value::binary, quote_char>>, quote_char)
+
+  defp parse_attribute_selector(<<quote_char, rest::binary>>, name, value, quote_char) do
+    case String.trim_leading(rest) do
+      "" -> {:ok, {name, value}}
+      _ -> :error
+    end
+  end
+
+  defp parse_attribute_selector(<<char, rest::binary>>, name, value, quote_char),
+    do: parse_attribute_selector(rest, name, <<value::binary, char>>, quote_char)
+
+  @doc """
+  Parses a CSS declaration block string into a list of maps.
+
+  ## Examples
+
+      iex> Premailex.CSSParser.parse_declaration_block("background-color: #fff; color: red;")
+      [
+        %{property: "background-color", value: "#fff", important?: false},
+        %{property: "color", value: "red", important?: false}
+      ]
+  """
+  @spec parse_declaration_block(String.t()) :: [declaration()]
+  def parse_declaration_block(declaration_block),
+    do: parse_declaration_block(declaration_block, "", nil, 0, nil, [])
+
+  defp parse_declaration_block(<<>>, _buffer, nil, _parens_depth, _quote_char, acc),
+    do: Enum.reverse(acc)
+
+  defp parse_declaration_block(<<>>, value, property, _parens_depth, _quote_char, acc),
+    do: Enum.reverse(add_declaration(acc, property, value))
+
+  defp parse_declaration_block(<<":", rest::binary>>, property, nil, 0, nil, acc),
+    do: parse_declaration_block(rest, "", property, 0, nil, acc)
+
+  defp parse_declaration_block(<<";", rest::binary>>, _buffer, nil, 0, nil, acc),
+    do: parse_declaration_block(rest, "", nil, 0, nil, acc)
+
+  defp parse_declaration_block(<<";", rest::binary>>, value, property, 0, nil, acc),
+    do: parse_declaration_block(rest, "", nil, 0, nil, add_declaration(acc, property, value))
+
+  defp parse_declaration_block(
+         <<quote_char, rest::binary>>,
+         buffer,
+         property,
+         parens_depth,
+         nil,
+         acc
+       )
+       when quote_char in [?", ?'] do
+    parse_declaration_block(
+      rest,
+      <<buffer::binary, quote_char>>,
+      property,
+      parens_depth,
+      quote_char,
+      acc
+    )
+  end
+
+  defp parse_declaration_block(
+         <<"\\", quote_char, rest::binary>>,
+         buffer,
+         property,
+         parens_depth,
+         quote_char,
+         acc
+       )
+       when quote_char in [?", ?'] do
+    parse_declaration_block(
+      rest,
+      <<buffer::binary, "\\", quote_char>>,
+      property,
+      parens_depth,
+      quote_char,
+      acc
+    )
+  end
+
+  defp parse_declaration_block(
+         <<quote_char, rest::binary>>,
+         buffer,
+         property,
+         parens_depth,
+         quote_char,
+         acc
+       )
+       when quote_char in [?", ?'],
+       do:
+         parse_declaration_block(
+           rest,
+           <<buffer::binary, quote_char>>,
+           property,
+           parens_depth,
+           nil,
+           acc
+         )
+
+  defp parse_declaration_block(<<"(", rest::binary>>, buffer, property, parens_depth, nil, acc),
+    do:
+      parse_declaration_block(rest, <<buffer::binary, "(">>, property, parens_depth + 1, nil, acc)
+
+  defp parse_declaration_block(<<")", rest::binary>>, buffer, property, parens_depth, nil, acc)
+       when parens_depth > 0,
+       do:
+         parse_declaration_block(
+           rest,
+           <<buffer::binary, ")">>,
+           property,
+           parens_depth - 1,
+           nil,
+           acc
+         )
+
+  defp parse_declaration_block(
+         <<char, rest::binary>>,
+         buffer,
+         property,
+         parens_depth,
+         quote_char,
+         acc
+       ),
+       do:
+         parse_declaration_block(
+           rest,
+           <<buffer::binary, char>>,
+           property,
+           parens_depth,
+           quote_char,
+           acc
+         )
+
+  defp add_declaration(acc, property, value) do
+    case {String.trim(property), String.trim(value)} do
+      {"", _} ->
+        acc
+
+      {_, ""} ->
+        acc
+
+      {property, value} ->
+        declaration =
+          %{
+            property: property,
+            value: value,
+            important?: value |> String.downcase() |> String.ends_with?("!important")
+          }
+
+        [declaration | acc]
+    end
   end
 
   @doc """
@@ -362,69 +942,60 @@ defmodule Premailex.CSSParser do
 
   ## Examples
 
-      iex> rule_sets = Premailex.CSSParser.parse("p {background-color: #fff !important; color: #000;} p {background-color: #000;}")
-      iex> Premailex.CSSParser.merge(rule_sets)
-      [%{directive: "background-color", value: "#fff !important", important?: true, specificity: 1},
-       %{directive: "color", value: "#000", important?: false, specificity: 1}]
+      iex> rules = Premailex.CSSParser.parse("p {background-color: #fff !important; color: #000;} p {background-color: #000;}")
+      iex> Premailex.CSSParser.merge(rules)
+      [
+        %{property: "background-color", value: "#fff !important", important?: true},
+        %{property: "color", value: "#000", important?: false}
+      ]
   """
-  @spec merge([rule_set]) :: [rule_set]
-  def merge(rule_sets) do
-    rule_sets
-    |> Enum.map(fn rule_set ->
-      Enum.map(rule_set.rules, &Map.put(&1, :specificity, rule_set.specificity))
+  @spec merge([rule()]) :: [declaration()]
+  def merge(rules) do
+    rules
+    |> Enum.reduce(%{}, fn %{declarations: declarations, specificity: specificity}, acc ->
+      Enum.reduce(declarations, acc, &merge_declaration(&2, &1, specificity))
     end)
-    |> Enum.reduce([], &Enum.concat(&2, &1))
-    |> merge_rule_sets
+    |> Enum.reduce([], fn {_property, {declaration, _specificity}}, acc ->
+      [declaration | acc]
+    end)
+    |> Enum.reverse()
   end
 
-  defp merge_rule_sets(rule_sets) do
-    rule_sets
-    |> Enum.reduce(%{}, &merge_into_rule_set(&2, &1))
-    |> Enum.into([], &elem(&1, 1))
-  end
+  defp merge_declaration(acc, declaration, specificity) do
+    # Cascading order: https://www.w3.org/TR/css-cascade-4/#cascading
+    Map.update(acc, declaration.property, {declaration, specificity}, fn {current_declaration,
+                                                                          current_specificity} ->
+      case {current_declaration.important?, declaration.important?} do
+        {true, false} ->
+          {current_declaration, current_specificity}
 
-  defp merge_into_rule_set(rule_set, new_rule) do
-    rule = rule_set |> Map.get(new_rule.directive, nil)
+        {false, true} ->
+          {declaration, specificity}
 
-    # Cascading order: http://www.w3.org/TR/CSS21/cascade.html#cascading-order
-    cond do
-      is_nil(rule) ->
-        Map.put(rule_set, new_rule.directive, new_rule)
-
-      new_rule.important? and (!rule.important? or rule.specificity <= new_rule.specificity) ->
-        Map.put(rule_set, new_rule.directive, new_rule)
-
-      !rule.important? and rule.specificity <= new_rule.specificity ->
-        Map.put(rule_set, new_rule.directive, new_rule)
-
-      true ->
-        rule_set
-    end
+        {important, important} ->
+          (specificity >= current_specificity && {declaration, specificity}) ||
+            {current_declaration, current_specificity}
+      end
+    end)
   end
 
   @doc """
-  Transforms CSS map or list into string.
+  Transforms a CSS rule declaration or a list of declarations into a string.
 
   ## Examples
 
-      iex> Premailex.CSSParser.to_string([%{directive: "background-color", value: "#fff"}, %{directive: "color", value: "#000"}])
-      "background-color: #fff; color: #000;"
+      iex> declarations = Premailex.CSSParser.parse_declaration_block("background-color: #fff !important; color: red;")
+      iex> Premailex.CSSParser.to_string(declarations)
+      "background-color: #fff !important; color: red;"
 
-      iex> Premailex.CSSParser.to_string(%{directive: "background-color", value: "#fff"})
+      iex> declarations = Premailex.CSSParser.parse_declaration_block("background-color: #fff")
+      iex> Premailex.CSSParser.to_string(declarations)
       "background-color: #fff;"
   """
-  @spec to_string([rule]) :: String.t()
-  def to_string(rules) when is_list(rules) do
-    Enum.map_join(rules, " ", &__MODULE__.to_string/1)
+  @spec to_string([declaration()] | declaration()) :: String.t()
+  def to_string(declarations) when is_list(declarations) do
+    Enum.map_join(declarations, " ", &__MODULE__.to_string/1)
   end
 
-  def to_string(%{directive: directive, value: value}), do: "#{directive}: #{value};"
-
-  defp calculate_specificity(selector) do
-    b = ~r/\#/ |> Regex.scan(selector) |> length()
-    c = @non_id_attributes_and_pseudo_classes |> Regex.scan(selector) |> length()
-    d = @elements_and_pseudo_elements |> Regex.scan(selector) |> length()
-
-    b + c + d
-  end
+  def to_string(%{property: property, value: value}), do: "#{property}: #{value};"
 end

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -7,7 +7,7 @@ defmodule Premailex.HTMLInlineStyles do
   alias Premailex.{CSSParser, HTMLParser, Util}
 
   @type html_or_html_tree() :: String.t() | HTMLParser.html_tree()
-  @type css_rule_sets_or_options() :: [CSSParser.rule_set()] | keyword()
+  @type css_rules_or_options() :: [CSSParser.rule()] | keyword()
 
   @doc """
   Processes an HTML string adding inline styles.
@@ -19,36 +19,36 @@ defmodule Premailex.HTMLInlineStyles do
       * `:all` - apply all optimization steps
       * `:remove_style_tags` - Remove style tags (can be combined in a list)
   """
-  @spec process(html_or_html_tree(), css_rule_sets_or_options() | nil, keyword() | nil) ::
+  @spec process(html_or_html_tree(), css_rules_or_options() | nil, keyword() | nil) ::
           String.t()
-  def process(html_or_tree, css_rule_sets_or_options \\ nil, options \\ nil)
+  def process(html_or_tree, css_rules_or_options \\ nil, options \\ nil)
 
-  def process(html, css_rule_sets_or_options, options) when is_binary(html) do
+  def process(html, css_rules_or_options, options) when is_binary(html) do
     html
     |> HTMLParser.parse()
-    |> process(css_rule_sets_or_options, options)
+    |> process(css_rules_or_options, options)
   end
 
-  def process(tree, css_rule_sets_or_options, nil) do
-    case Keyword.keyword?(css_rule_sets_or_options) do
-      true -> process(tree, nil, css_rule_sets_or_options)
-      false -> process(tree, css_rule_sets_or_options, [])
+  def process(tree, css_rules_or_options, nil) do
+    case Keyword.keyword?(css_rules_or_options) do
+      true -> process(tree, nil, css_rules_or_options)
+      false -> process(tree, css_rules_or_options, [])
     end
   end
 
   def process(tree, nil, options) do
     css_selector = Keyword.get(options, :css_selector, "style,link[rel=\"stylesheet\"][href]")
-    css_rule_sets = load_styles(tree, css_selector)
+    css_rules = load_styles(tree, css_selector)
     options = Keyword.put_new(options, :css_selector, css_selector)
 
-    process(tree, css_rule_sets, options)
+    process(tree, css_rules, options)
   end
 
-  def process(tree, css_rules_sets, options) do
+  def process(tree, css_rules, options) do
     optimize_steps = Keyword.get(options, :optimize, :none)
     optimize_options = Keyword.take(options, [:css_selector])
 
-    css_rules_sets
+    css_rules
     |> apply_styles(tree)
     |> normalize_styles()
     |> optimize(optimize_steps, optimize_options)
@@ -125,23 +125,30 @@ defmodule Premailex.HTMLInlineStyles do
     nil
   end
 
-  defp add_rules_to_html_tree(%{selector: selector, rules: rules, specificity: specificity}, tree) do
+  defp add_rules_to_html_tree(
+         %{selector: selector, declarations: declarations, specificity: specificity},
+         tree
+       ) do
     tree
     |> HTMLParser.all(selector)
-    |> Enum.reduce(tree, &update_style_for_html_tree(&2, &1, rules, specificity))
+    |> Enum.reduce(tree, &update_style_for_html_tree(&2, &1, declarations, specificity))
   end
 
-  defp update_style_for_html_tree(tree, needle, rules, specificity) do
-    Util.traverse_until_first(tree, needle, &update_style_for_element(&1, rules, specificity))
+  defp update_style_for_html_tree(tree, needle, declarations, specificity) do
+    Util.traverse_until_first(
+      tree,
+      needle,
+      &update_style_for_element(&1, declarations, specificity)
+    )
   end
 
-  defp update_style_for_element({name, attrs, children}, rules, specificity) do
+  defp update_style_for_element({name, attrs, children}, declarations, specificity) do
     style =
       attrs
       |> Enum.into(%{})
       |> Map.get("style", nil)
       |> set_inline_style_specificity()
-      |> add_styles_with_specificity(rules, specificity)
+      |> add_styles_with_specificity(declarations, specificity)
 
     {name, put_style_attr(attrs, style), children}
   end
@@ -152,10 +159,19 @@ defmodule Premailex.HTMLInlineStyles do
 
   defp set_inline_style_specificity(nil), do: ""
   defp set_inline_style_specificity("[SPEC=" <> _rest = style), do: style
-  defp set_inline_style_specificity(style), do: "[SPEC=1000[#{style}]]"
 
-  defp add_styles_with_specificity(style, rules, specificity) do
-    "#{style}[SPEC=#{specificity}[#{CSSParser.to_string(rules)}]]"
+  defp set_inline_style_specificity(style),
+    do: "[SPEC=#{format_specificity({1, 0, 0, 0})}[#{style}]]"
+
+  defp add_styles_with_specificity(style, declarations, specificity) do
+    "#{style}[SPEC=#{format_specificity(specificity)}[#{CSSParser.to_string(declarations)}]]"
+  end
+
+  defp format_specificity({a, b, c, d}), do: "#{a}.#{b}.#{c}.#{d}"
+
+  defp parse_specificity(str) do
+    [a, b, c, d] = str |> String.split(".") |> Enum.map(&String.to_integer/1)
+    {a, b, c, d}
   end
 
   defp normalize_styles(tree) do
@@ -175,10 +191,13 @@ defmodule Premailex.HTMLInlineStyles do
       |> Map.get("style")
 
     style =
-      ~r/\[SPEC\=([\d]+)\[(.[^\]\]]*)\]\]/
+      ~r/\[SPEC\=(\d+\.\d+\.\d+\.\d+)\[(.[^\]\]]*)\]\]/
       |> Regex.scan(current_style)
-      |> Enum.map(fn [_, specificity, rule] ->
-        %{specificity: specificity, rules: CSSParser.parse_rules(rule)}
+      |> Enum.map(fn [_, specificity, declaration_block] ->
+        %{
+          specificity: parse_specificity(specificity),
+          declarations: CSSParser.parse_declaration_block(declaration_block)
+        }
       end)
       |> CSSParser.merge()
       |> CSSParser.to_string()

--- a/test/premailex/css_parser_test.exs
+++ b/test/premailex/css_parser_test.exs
@@ -2,7 +2,14 @@ defmodule Premailex.CSSParserTest do
   use ExUnit.Case
   doctest Premailex.CSSParser
 
+  alias Premailex.CSSParser
+
+  import ExUnit.CaptureLog
+
   @input """
+  @charset "UTF-8";
+  @import url("a;b'.css");
+  @import "with\\"-escaped-quote.css";
   body, table {/* text-decoration:underline */background-color:#ffffff;background-image:url('http://example.com/image.png');color:#000000;}
   div p > a:hover {color:#000000 !important;text-decoration:underline}
   /*div {
@@ -24,107 +31,187 @@ defmodule Premailex.CSSParserTest do
 
   @parsed [
     %{
-      rules: [
-        %{directive: "background-color", value: "#ffffff", important?: false},
+      declarations: [
+        %{property: "background-color", value: "#ffffff", important?: false},
         %{
-          directive: "background-image",
+          property: "background-image",
           value: "url('http://example.com/image.png')",
           important?: false
         },
-        %{directive: "color", value: "#000000", important?: false}
+        %{property: "color", value: "#000000", important?: false}
       ],
       selector: "body",
-      specificity: 1
+      specificity: {0, 0, 0, 1}
     },
     %{
-      rules: [
-        %{directive: "background-color", value: "#ffffff", important?: false},
+      declarations: [
+        %{property: "background-color", value: "#ffffff", important?: false},
         %{
-          directive: "background-image",
+          property: "background-image",
           value: "url('http://example.com/image.png')",
           important?: false
         },
-        %{directive: "color", value: "#000000", important?: false}
+        %{property: "color", value: "#000000", important?: false}
       ],
       selector: "table",
-      specificity: 1
+      specificity: {0, 0, 0, 1}
     },
     %{
-      rules: [
-        %{directive: "color", value: "#000000 !important", important?: true},
-        %{directive: "text-decoration", value: "underline", important?: false}
+      declarations: [
+        %{property: "color", value: "#000000 !important", important?: true},
+        %{property: "text-decoration", value: "underline", important?: false}
       ],
       selector: "div p > a:hover",
-      specificity: 4
+      specificity: {0, 0, 1, 3}
     },
     %{
-      rules: [],
+      declarations: [],
       selector: ".with\\,escaped\\,commas",
-      specificity: 1
+      specificity: {0, 0, 1, 0}
     },
     %{
-      rules: [],
+      declarations: [],
       selector: ".with-empty-selector",
-      specificity: 1
+      specificity: {0, 0, 1, 0}
     }
   ]
 
-  test "parse/1" do
-    assert Premailex.CSSParser.parse(@input) == @parsed
+  describe "parse/1" do
+    test "with empty input" do
+      assert CSSParser.parse("") == []
+      assert CSSParser.parse("   \n\t  \r\n") == []
+    end
+
+    test "with unterminated comment" do
+      assert CSSParser.parse("""
+             h1 {
+               color: blue;
+             }
+             div {
+               color: red; /* unclosed comment
+               padding: 10px;
+             }
+             """) ==
+               [
+                 %{
+                   declarations: [%{property: "color", value: "blue", important?: false}],
+                   selector: "h1",
+                   specificity: {0, 0, 0, 1}
+                 }
+               ]
+    end
+
+    test "with unterminated at-rule string" do
+      assert CSSParser.parse("""
+             h1 { color: blue; }
+             @import "unclosed string;
+             div { color: red; }
+             """) == [
+               %{
+                 declarations: [%{value: "blue", property: "color", important?: false}],
+                 selector: "h1",
+                 specificity: {0, 0, 0, 1}
+               }
+             ]
+    end
+
+    test "with unterminated at-rule block" do
+      assert CSSParser.parse("""
+             h1 { color: blue; }
+             @media (max-width: 600px) {
+               body {
+                 color: red;
+             }
+             div { color: red; }
+             """) == [
+               %{
+                 declarations: [%{value: "blue", property: "color", important?: false}],
+                 selector: "h1",
+                 specificity: {0, 0, 0, 1}
+               }
+             ]
+    end
+
+    test "with unterminated rule block" do
+      assert CSSParser.parse("""
+             h1 { color: blue; }
+             div { color: red;
+             span { color: green; }
+             """) ==
+               [
+                 %{
+                   declarations: [%{property: "color", value: "blue", important?: false}],
+                   selector: "h1",
+                   specificity: {0, 0, 0, 1}
+                 }
+               ]
+    end
+
+    test "with rule block with missing selector" do
+      assert CSSParser.parse("""
+             { color: red; }
+             h1 { color: blue; }
+             """) ==
+               [
+                 %{
+                   declarations: [%{property: "color", value: "blue", important?: false}],
+                   selector: "h1",
+                   specificity: {0, 0, 0, 1}
+                 }
+               ]
+    end
+
+    test "with rule with missing value" do
+      assert CSSParser.parse("""
+             h1 { color: ; }
+             div { color: }
+             """) ==
+               [
+                 %{declarations: [], selector: "h1", specificity: {0, 0, 0, 1}},
+                 %{declarations: [], selector: "div", specificity: {0, 0, 0, 1}}
+               ]
+    end
+
+    test "parses" do
+      assert CSSParser.parse(@input) == @parsed
+    end
+
+    test "with varying specificity" do
+      assert [
+               %{
+                 selector: "div#id.cls1.cls2[a][b]:hover > p",
+                 specificity: {0, 1, 5, 2} = specificity_1
+               },
+               %{
+                 selector: "*::before",
+                 specificity: {0, 0, 0, 1} = specificity_2
+               }
+             ] =
+               CSSParser.parse("""
+               div#id.cls1.cls2[a][b]:hover > p { color: red; }
+               *::before { content: ''; }
+               """)
+
+      assert specificity_1 > specificity_2
+    end
   end
 
   describe "split_selector_groups/1" do
     test "with empty selector" do
-      assert Premailex.CSSParser.split_selector_groups("") == []
-    end
-
-    test "with commas selector" do
-      assert Premailex.CSSParser.split_selector_groups(",,,,") == []
+      assert CSSParser.split_selector_groups("") == []
     end
 
     test "with whitespace selector" do
-      assert Premailex.CSSParser.split_selector_groups("\t") == []
-      assert Premailex.CSSParser.split_selector_groups("    ") == []
+      assert CSSParser.split_selector_groups("\t") == []
+      assert CSSParser.split_selector_groups("    ") == []
     end
 
-    test "with attribute selector with quoted value" do
-      assert Premailex.CSSParser.split_selector_groups(~s([data='a,b,c'] + [data="x,y"], .bar)) ==
-               [~s([data='a,b,c'] + [data="x,y"]), ".bar"]
-    end
-
-    test "with attribute selector with quoted value containing quote" do
-      assert Premailex.CSSParser.split_selector_groups(~s([data='a,"b,c'] + [data="x,'y"], .bar)) ==
-               [~s([data='a,"b,c'] + [data="x,'y"]), ".bar"]
-    end
-
-    test "with attribute selector with quoted value with escaped quotes" do
-      assert Premailex.CSSParser.split_selector_groups(
-               ~s([data='a,\\'b,c'] + [data="x,\\"y"], .bar)
-             ) == [
-               ~s([data='a,\\'b,c'] + [data="x,\\"y"]),
-               ".bar"
-             ]
-    end
-
-    test "with attribute selector with malformed quoted value" do
-      assert Premailex.CSSParser.split_selector_groups(~s([data="a,b,c], .foo)) == [
-               ~s([data="a,b,c], .foo)
-             ]
-
-      assert Premailex.CSSParser.split_selector_groups(~s([data=a,b,c"], .foo)) == [
-               ~s([data=a,b,c"], .foo)
-             ]
-    end
-
-    test "with attribute selector with quoted value with newlines" do
-      assert Premailex.CSSParser.split_selector_groups("[data=\"line1\nline2\"], .foo") == [
-               "[data=\"line1\nline2\"]",
-               ".foo"
-             ]
+    test "with commas selector" do
+      assert CSSParser.split_selector_groups(",,,,") == []
     end
 
     test "with comma separated selectors" do
-      assert Premailex.CSSParser.split_selector_groups("div  ,  .foo,\t.bar") == [
+      assert CSSParser.split_selector_groups("div  ,  .foo,\t.bar") == [
                "div",
                ".foo",
                ".bar"
@@ -132,7 +219,7 @@ defmodule Premailex.CSSParserTest do
     end
 
     test "with comma separated selectors with newlines" do
-      assert Premailex.CSSParser.split_selector_groups("""
+      assert CSSParser.split_selector_groups("""
                div ,
              .foo,
              .bar
@@ -140,225 +227,434 @@ defmodule Premailex.CSSParserTest do
     end
 
     test "with comma separated selectors with consecutive commas" do
-      assert Premailex.CSSParser.split_selector_groups(",.foo,,,.bar,,") == [".foo", ".bar"]
+      assert CSSParser.split_selector_groups(",.foo,,,.bar,,") == [".foo", ".bar"]
     end
 
     test "with comma separated selectors with escaped commas" do
-      assert Premailex.CSSParser.split_selector_groups(".with\\,escaped\\,commas") == [
+      assert CSSParser.split_selector_groups(".with\\,escaped\\,commas") == [
                ~s(.with\\,escaped\\,commas)
              ]
     end
 
     test "with attribute selector" do
-      assert Premailex.CSSParser.split_selector_groups("span[data-y], .foo") ==
+      assert CSSParser.split_selector_groups("span[data-y], .foo") ==
                ["span[data-y]", ".foo"]
     end
 
     test "with attribute selector with brackets" do
-      assert Premailex.CSSParser.split_selector_groups("[[data]], .foo") == [
+      assert CSSParser.split_selector_groups("[[data]], .foo") == [
                "[[data]]",
-               ".foo"
-             ]
-
-      assert Premailex.CSSParser.split_selector_groups(~s([href="a]b"], [data-x="a[b"])) ==
-               [~s([href="a]b"]), ~s([data-x="a[b"])]
-    end
-
-    test "with malformed attribute selector" do
-      assert Premailex.CSSParser.split_selector_groups("[data, .foo") == ["[data, .foo"]
-
-      assert Premailex.CSSParser.split_selector_groups("data], .foo") == [
-               "data]",
                ".foo"
              ]
     end
 
     test "with attribute selector with newlines" do
-      assert Premailex.CSSParser.split_selector_groups("[data\nattr], .foo") == [
+      assert CSSParser.split_selector_groups("[data\nattr], .foo") == [
                "[data\nattr]",
                ".foo"
              ]
     end
 
-    test "with functional pseudo-class selector" do
-      assert Premailex.CSSParser.split_selector_groups("div:not(.foo, .bar), .baz") == [
+    test "with malformed attribute selector" do
+      assert CSSParser.split_selector_groups("[data, .foo") == ["[data, .foo"]
+
+      assert CSSParser.split_selector_groups("data], .foo") == [
+               "data]",
+               ".foo"
+             ]
+    end
+
+    test "with attribute selector with quoted value" do
+      assert CSSParser.split_selector_groups(~s([data='a,b,c'] + [data="x,y"], .bar)) ==
+               [~s([data='a,b,c'] + [data="x,y"]), ".bar"]
+    end
+
+    test "with attribute selector with quoted value containing quote" do
+      assert CSSParser.split_selector_groups(~s([data='a,"b,c'] + [data="x,'y"], .bar)) ==
+               [~s([data='a,"b,c'] + [data="x,'y"]), ".bar"]
+    end
+
+    test "with attribute selector with quoted value with escaped quotes" do
+      assert CSSParser.split_selector_groups(~s([data='a,\\'b,c'] + [data="x,\\"y"], .bar)) == [
+               ~s([data='a,\\'b,c'] + [data="x,\\"y"]),
+               ".bar"
+             ]
+    end
+
+    test "with attribute selector with quoted value containing brackets" do
+      assert CSSParser.split_selector_groups(~s([href="a]b"], [data-x="a[b"])) ==
+               [~s([href="a]b"]), ~s([data-x="a[b"])]
+    end
+
+    test "with attribute selector with quoted value with newlines" do
+      assert CSSParser.split_selector_groups("[data=\"line1\nline2\"], .foo") == [
+               "[data=\"line1\nline2\"]",
+               ".foo"
+             ]
+    end
+
+    test "with attribute selector with malformed quoted value" do
+      assert CSSParser.split_selector_groups(~s([data="a,b,c], .foo)) == [
+               ~s([data="a,b,c], .foo)
+             ]
+
+      assert CSSParser.split_selector_groups(~s([data=a,b,c"], .foo)) == [
+               ~s([data=a,b,c"], .foo)
+             ]
+    end
+
+    test "with functional pseudo class selector" do
+      assert CSSParser.split_selector_groups("div:not(.foo, .bar), .baz") == [
                "div:not(.foo, .bar)",
                ".baz"
              ]
     end
 
-    test "with nested functional pseudo-class selector" do
-      assert Premailex.CSSParser.split_selector_groups("div:is(:not(.foo, .bar), .baz), .qux") ==
+    test "with nested functional pseudo class selector" do
+      assert CSSParser.split_selector_groups("div:is(:not(.foo, .bar), .baz), .qux") ==
                [
                  "div:is(:not(.foo, .bar), .baz)",
                  ".qux"
                ]
     end
 
-    test "with malformed functional pseudo-class selector" do
-      assert Premailex.CSSParser.split_selector_groups("div:not(.foo, .bar, .baz") == [
+    test "with functional pseudo class selector with newlines" do
+      assert CSSParser.split_selector_groups("div:not(\n.foo, .bar\n), .baz") == [
+               "div:not(\n.foo, .bar\n)",
+               ".baz"
+             ]
+    end
+
+    test "with malformed functional pseudo class selector" do
+      assert CSSParser.split_selector_groups("div:not(.foo, .bar, .baz") == [
                "div:not(.foo, .bar, .baz"
              ]
 
-      assert Premailex.CSSParser.split_selector_groups("div:not.foo, .bar), .baz)") == [
+      assert CSSParser.split_selector_groups("div:not.foo, .bar), .baz)") == [
                "div:not.foo",
                ".bar)",
                ".baz)"
              ]
     end
+  end
 
-    test "with functional pseudo-class selector with newlines" do
-      assert Premailex.CSSParser.split_selector_groups("div:not(\n.foo, .bar\n), .baz") == [
-               "div:not(\n.foo, .bar\n)",
-               ".baz"
-             ]
+  describe "parse_selector_groups/1" do
+    test "with tag selector" do
+      assert [[%{tag: "p"}]] = CSSParser.parse_selector_groups("p")
+      assert [[%{tag: "*"}]] = CSSParser.parse_selector_groups("*")
+    end
+
+    test "with id selector" do
+      assert [[%{id: "main"}]] = CSSParser.parse_selector_groups("#main")
+    end
+
+    test "with invalid id selector" do
+      assert_invalid_selector("body#")
+      assert_invalid_selector("##main")
+      assert_invalid_selector("#.container")
+      assert_invalid_selector("#:first-of-type")
+      assert_invalid_selector("#[href]")
+      assert_invalid_selector("# div")
+    end
+
+    test "with class selector" do
+      assert [[%{classes: ["a"]}]] = CSSParser.parse_selector_groups(".a")
+      assert [[%{classes: ["a", "b"]}]] = CSSParser.parse_selector_groups(".a.b")
+    end
+
+    test "with invalid class selector" do
+      assert_invalid_selector("p.")
+      assert_invalid_selector("..x")
+      assert_invalid_selector(".#x")
+      assert_invalid_selector(".:x")
+      assert_invalid_selector(".[a]")
+      assert_invalid_selector(". x")
+      assert_invalid_selector(".(x)")
+    end
+
+    test "with attribute selector" do
+      assert [[%{attrs: ["href"]}]] = CSSParser.parse_selector_groups("[href]")
+      assert [[%{attrs: ["href"]}]] = CSSParser.parse_selector_groups("[ href\n\t]")
+
+      assert [[%{attrs: [{"href", "/go"}]}]] = CSSParser.parse_selector_groups(~s([href="/go"]))
+      assert [[%{attrs: [{"href", "/go"}]}]] = CSSParser.parse_selector_groups(~s([href='/go']))
+      assert [[%{attrs: [{"href", "/go"}]}]] = CSSParser.parse_selector_groups("[href=/go]")
+
+      assert [[%{attrs: [{"href", "/go"}]}]] =
+               CSSParser.parse_selector_groups(~s([\nhref="/go"\t ]))
+
+      assert [[%{attrs: ["href", {"class", "cta"}]}]] =
+               CSSParser.parse_selector_groups("[href][class=cta]")
+    end
+
+    test "with attribute selector with value containing special chars" do
+      assert [[%{attrs: [{"x", "a b"}]}]] =
+               CSSParser.parse_selector_groups(~s([x="a b"]))
+
+      assert [[%{attrs: [{"x", "a,b"}]}]] =
+               CSSParser.parse_selector_groups(~s([x='a,b']))
+
+      assert [[%{attrs: [{"x", "a'b"}]}]] =
+               CSSParser.parse_selector_groups(~s([x="a'b"]))
+
+      assert [[%{attrs: [{"x", "a\"b"}]}]] =
+               CSSParser.parse_selector_groups(~S([x="a\"b"]))
+
+      assert [[%{attrs: [{"x", "a[b"}]}]] =
+               CSSParser.parse_selector_groups(~s([x="a[b"]))
+
+      assert [[%{attrs: [{"x", "a]b"}]}]] =
+               CSSParser.parse_selector_groups(~s([x="a]b"]))
+
+      assert [[%{attrs: [{"x", "a(b"}]}]] =
+               CSSParser.parse_selector_groups(~s|[x="a(b"]|)
+
+      assert [[%{attrs: [{"x", "a)b"}]}]] =
+               CSSParser.parse_selector_groups(~s|[x="a)b"]|)
+    end
+
+    test "with invalid attribute selector" do
+      assert_invalid_selector("a[")
+      assert_invalid_selector("a]")
+      assert_invalid_selector("a[]")
+      assert_invalid_selector("a[[href]")
+      assert_invalid_selector("a[[href]]")
+      assert_invalid_selector("a[href href]")
+      assert_invalid_selector(~s(a[href=/"go]))
+      assert_invalid_selector(~s(a[href="/go]))
+      assert_invalid_selector(~s(a[href="/g"o]))
+      assert_invalid_selector(~s|a[href=/g(o]|)
+      assert_invalid_selector(~s|a[href=/go)]|)
+    end
+
+    test "with pseudo class selector" do
+      assert [[%{pseudos: [%{name: "first-of-type", expression: nil, kind: :pseudo_class}]}]] =
+               CSSParser.parse_selector_groups(":first-of-type")
+
+      assert [[%{pseudos: [%{name: "nth-child", expression: "2", kind: :pseudo_class}]}]] =
+               CSSParser.parse_selector_groups(":nth-child(2)")
+
+      assert [[%{pseudos: [%{name: "required"}, %{name: "invalid"}]}]] =
+               CSSParser.parse_selector_groups(":required:invalid")
+
+      assert [[%{pseudos: [%{name: "not", expression: ":has(.foo)"}]}]] =
+               CSSParser.parse_selector_groups(":not(:has(.foo))")
+
+      assert [[%{pseudos: [%{name: "not", expression: ".a > .b"}]}]] =
+               CSSParser.parse_selector_groups(":not(.a > .b)")
+    end
+
+    test "with invalid pseudo class selector" do
+      assert_invalid_selector("a:")
+      assert_invalid_selector(":#x")
+      assert_invalid_selector(":.x")
+      assert_invalid_selector(":[a]")
+      assert_invalid_selector(": x")
+      assert_invalid_selector("a:()")
+      assert_invalid_selector("p:nth-child(")
+      assert_invalid_selector("p:nth-child(2))")
+    end
+
+    test "with pseudo element selector" do
+      assert [[%{pseudos: [%{name: "before", kind: :pseudo_element}]}]] =
+               CSSParser.parse_selector_groups("::before")
+
+      assert [[%{pseudos: [%{name: "part", expression: "title", kind: :pseudo_element}]}]] =
+               CSSParser.parse_selector_groups("::part(title)")
+    end
+
+    test "with invalid pseudo element selector" do
+      assert_invalid_selector("a::")
+      assert_invalid_selector("a::()")
+    end
+
+    test "with descendant combinator selector" do
+      assert [[%{tag: "p", combinator: nil}, %{tag: "body", combinator: :descendant}]] =
+               CSSParser.parse_selector_groups("body p")
+
+      assert [[%{tag: "p", combinator: nil}, %{tag: "body", combinator: :descendant}]] =
+               CSSParser.parse_selector_groups("  body   p  ")
+
+      assert [[%{tag: "p", combinator: nil}, %{tag: "body", combinator: :descendant}]] =
+               CSSParser.parse_selector_groups("body\np")
+    end
+
+    test "with child combinator selector" do
+      assert [[%{tag: "p", combinator: nil}, %{tag: "body", combinator: :child}]] =
+               CSSParser.parse_selector_groups("body>p")
+
+      assert [[%{tag: "p", combinator: nil}, %{tag: "body", combinator: :child}]] =
+               CSSParser.parse_selector_groups("body\n>\np")
+    end
+
+    test "with adjacent sibling combinator selector" do
+      assert [[%{tag: "p", combinator: nil}, %{tag: "div", combinator: :adjacent}]] =
+               CSSParser.parse_selector_groups("div + p")
+    end
+
+    test "with general sibling combinator selector" do
+      assert [[%{tag: "p", combinator: nil}, %{tag: "div", combinator: :sibling}]] =
+               CSSParser.parse_selector_groups("div ~ p")
+    end
+
+    test "with column combinator selector" do
+      assert [[%{tag: "p", combinator: nil}, %{tag: "div", combinator: :column}]] =
+               CSSParser.parse_selector_groups("div || p")
+    end
+
+    test "with invalid combinator selector" do
+      assert_invalid_selector("> p")
+      assert_invalid_selector("+ p")
+      assert_invalid_selector("~ p")
+      assert_invalid_selector("|| p")
+      assert_invalid_selector("div >")
+      assert_invalid_selector("div +")
+      assert_invalid_selector("div ~")
+      assert_invalid_selector("div ||")
+      assert_invalid_selector("div > > p")
+    end
+
+    test "with multiple selector groups" do
+      assert [[%{tag: "p", classes: ["intro"]}], [%{tag: "a", classes: ["cta"]}]] =
+               CSSParser.parse_selector_groups("p.intro, a.cta")
     end
   end
 
-  describe "parse_rules/1" do
-    test "with empty rule" do
-      assert Premailex.CSSParser.parse_rules("") == []
+  defp assert_invalid_selector(selector) do
+    assert capture_log(fn ->
+             assert CSSParser.parse_selector_groups(selector) == [[]]
+           end) =~ ~s(Invalid selector group "#{selector}". Ignoring.)
+  end
+
+  describe "parse_declaration_block/1" do
+    test "with empty declaration block" do
+      assert CSSParser.parse_declaration_block("") == []
+      assert CSSParser.parse_declaration_block("   \n\t  \r\n") == []
     end
 
-    test "with semicolon rule" do
-      assert Premailex.CSSParser.parse_rules(";;;;") == []
+    test "with semicolon declaration block" do
+      assert CSSParser.parse_declaration_block(";;;;") == []
     end
 
-    test "with whitespace rule" do
-      assert Premailex.CSSParser.parse_rules("\t") == []
-      assert Premailex.CSSParser.parse_rules("    ") == []
+    test "with declaration missing property" do
+      assert CSSParser.parse_declaration_block("color red") == []
+      assert CSSParser.parse_declaration_block(": red") == []
     end
 
-    test "with rule" do
-      assert Premailex.CSSParser.parse_rules("color: red;background-color: blue;") ==
+    test "with declaration missing value" do
+      assert CSSParser.parse_declaration_block("color") == []
+      assert CSSParser.parse_declaration_block("color: ") == []
+    end
+
+    test "with declaration" do
+      assert CSSParser.parse_declaration_block("color: red;background-color: blue;") ==
                [
-                 %{directive: "color", value: "red", important?: false},
-                 %{directive: "background-color", value: "blue", important?: false}
+                 %{property: "color", value: "red", important?: false},
+                 %{property: "background-color", value: "blue", important?: false}
                ]
     end
 
-    test "with rule with !important value" do
-      assert Premailex.CSSParser.parse_rules("""
+    test "with declaration without trailing semicolon" do
+      assert CSSParser.parse_declaration_block("color: red") ==
+               [
+                 %{property: "color", value: "red", important?: false}
+               ]
+    end
+
+    test "with declarations with newline" do
+      assert CSSParser.parse_declaration_block("""
+             color: red;
+             background:
+             blue;
+             """) ==
+               [
+                 %{property: "color", value: "red", important?: false},
+                 %{property: "background", value: "blue", important?: false}
+               ]
+    end
+
+    test "with declarations with whitespace" do
+      assert CSSParser.parse_declaration_block("""
+             color  :  red  ;
+             background:\tblue\t;
+             """) ==
+               [
+                 %{property: "color", value: "red", important?: false},
+                 %{property: "background", value: "blue", important?: false}
+               ]
+    end
+
+    test "with declaration with !important value" do
+      assert CSSParser.parse_declaration_block("""
              color: red !important ;
              background-color: blue !IMPORTANT;
              text-decoration: underline !important;
              width: 100px!important
              """) ==
                [
-                 %{directive: "color", value: "red !important", important?: true},
-                 %{directive: "background-color", value: "blue !IMPORTANT", important?: true},
-                 %{directive: "text-decoration", value: "underline !important", important?: true},
-                 %{directive: "width", value: "100px!important", important?: true}
+                 %{property: "color", value: "red !important", important?: true},
+                 %{property: "background-color", value: "blue !IMPORTANT", important?: true},
+                 %{property: "text-decoration", value: "underline !important", important?: true},
+                 %{property: "width", value: "100px!important", important?: true}
                ]
     end
 
-    test "with rule with malformed !important" do
-      assert Premailex.CSSParser.parse_rules(
+    test "with declaration with malformed !important" do
+      assert CSSParser.parse_declaration_block(
                "color: !important red;background: blue !important\""
              ) ==
                [
-                 %{directive: "color", value: "!important red", important?: false},
-                 %{directive: "background", value: "blue !important\"", important?: false}
+                 %{property: "color", value: "!important red", important?: false},
+                 %{property: "background", value: "blue !important\"", important?: false}
                ]
     end
 
-    test "with rules with newline" do
-      assert Premailex.CSSParser.parse_rules("""
+    test "with malformed declaration" do
+      assert CSSParser.parse_declaration_block("color red background: blue") ==
+               [
+                 %{property: "color red background", value: "blue", important?: false}
+               ]
+    end
+
+    test "with declaration value containing semicolon" do
+      assert CSSParser.parse_declaration_block("""
+             content: "a;b";
+             background: url(data:image/png;base64,abc);
              color: red;
-             background:
-             blue;
-             """) ==
-               [
-                 %{directive: "color", value: "red", important?: false},
-                 %{directive: "background", value: "blue", important?: false}
-               ]
-    end
-
-    test "with rules with varying whitespace" do
-      assert Premailex.CSSParser.parse_rules("""
-             color  :  red  ;
-             background:\tblue\t;
-             """) ==
-               [
-                 %{directive: "color", value: "red", important?: false},
-                 %{directive: "background", value: "blue", important?: false}
-               ]
-    end
-
-    test "with rule without trailing semicolon" do
-      assert Premailex.CSSParser.parse_rules("color: red") ==
-               [
-                 %{directive: "color", value: "red", important?: false}
-               ]
-    end
-
-    test "with malformed rule" do
-      assert Premailex.CSSParser.parse_rules("color red background: blue") ==
-               [
-                 %{directive: "color red background", value: "blue", important?: false}
-               ]
+             """) == [
+               %{property: "content", value: "\"a;b\"", important?: false},
+               %{
+                 property: "background",
+                 value: "url(data:image/png;base64,abc)",
+                 important?: false
+               },
+               %{property: "color", value: "red", important?: false}
+             ]
     end
   end
 
-  describe "calculate_specificity/1 edge cases" do
-    test "complex selector chain" do
-      css = "div#id.class1.class2[attr1][attr2]:hover > p { color: red; }"
-      parsed = Premailex.CSSParser.parse(css)
-      [rule_set] = parsed
-      # 1 id + 2 classes + 2 attributes + 1 pseudo-class + 2 elements = 8
-      assert rule_set.specificity == 8
-    end
+  test "merge/1" do
+    rules =
+      CSSParser.parse("""
+      p { color: red !important; font-size: 12px; }
+      p { color: blue; font-size: 14px; }
+      """)
 
-    test "pseudo-element" do
-      css = "div::before { content: 'test'; }"
-      parsed = Premailex.CSSParser.parse(css)
-      [rule_set] = parsed
-      # 1 element + 1 pseudo-element = 2
-      assert rule_set.specificity == 2
-    end
-
-    test "only pseudo-classes" do
-      css = ":hover:focus:active { color: blue; }"
-      parsed = Premailex.CSSParser.parse(css)
-      [rule_set] = parsed
-      # 3 pseudo-classes
-      assert rule_set.specificity == 3
-    end
+    assert CSSParser.merge(rules) == [
+             %{property: "color", value: "red !important", important?: true},
+             %{property: "font-size", value: "14px", important?: false}
+           ]
   end
 
-  describe "full parse/1 edge cases" do
-    test "selectors with attribute containing comma and space" do
-      css = "div[data-x=\"a, b\"] { color: red; }"
-      parsed = Premailex.CSSParser.parse(css)
-      assert length(parsed) == 1
-      assert Enum.find(parsed, fn r -> r.selector == "div[data-x=\"a, b\"]" end)
-    end
+  test "to_string/1" do
+    [%{declarations: [declaration_1, declaration_2]}] =
+      CSSParser.parse("""
+      p { color: red !important; font-size: 12px; }
+      """)
 
-    test "multiple selectors with complex nesting" do
-      css = """
-        a[href="http://example.com?x=1,y=2"],
-        b:not(div),
-        c > d[data='test'] { color: blue; }
-      """
+    assert CSSParser.to_string(declaration_1) == "color: red !important;"
 
-      parsed = Premailex.CSSParser.parse(css)
-      assert length(parsed) == 3
-      assert Enum.find(parsed, fn r -> String.contains?(r.selector, "href=") end)
-      assert Enum.find(parsed, fn r -> String.contains?(r.selector, ":not(div)") end)
-    end
-
-    test "empty selector block" do
-      css = "div { }"
-      parsed = Premailex.CSSParser.parse(css)
-      assert length(parsed) == 1
-      assert Enum.find(parsed, fn r -> r.rules == [] end)
-    end
-
-    test "rule without value" do
-      css = "div { color: ; }"
-      parsed = Premailex.CSSParser.parse(css)
-      assert length(parsed) == 1
-      # Should still parse, even if value is empty
-    end
+    assert CSSParser.to_string([declaration_1, declaration_2]) ==
+             "color: red !important; font-size: 12px;"
   end
 end


### PR DESCRIPTION
Resolves #30 and no longer uses regular expression to parse CSS.

Adds much tighter parsing controls. Also conformed the CSS terminology.