### PR TITLE
Improve performance

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,3 @@
 [
-  inputs: ["{mix,.formatter}.exs", "{lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{lib,test,benchmark}/**/*.{ex,exs}"]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Requires Elixir 1.14 or higher.
 * `Premailex.CSSParser` rewritten and no longer uses regular expression to parse CSS
 * Renamed `Premailex.CSSParser.parse_rules/1` to `Premailex.CSSParser.parse_declaration_block/1`
 * `Premailex.CSSParser.parse_declaration_block/1` now does case insensitive, terminal `!important` detection
+* `Premailex.HTMLInlineStyles.process/3` tree traversal performance changed from O(N^2) to O(N)
 
 ## v0.3.20 (2025-01-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Requires Elixir 1.14 or higher.
 * `Premailex.CSSParser.parse_declaration_block/1` now does case insensitive, terminal `!important` detection
 * `Premailex.HTMLInlineStyles.process/3` tree traversal performance changed from O(N^2) to O(N)
 * `Premailex.Util.traverse_and_update/2` added
+* `Premailex.Util.traverse_reduce/3` removed
 
 ## v0.3.20 (2025-01-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Requires Elixir 1.14 or higher.
 
+This release contains significant performance improvements with typical HTML emails seeing a ~4x speedup when inlining styles.
+
 * Fixed compiler warnings in `Premailex.HTMLParser.Meeseeks`
 * Fixed invalid spec in `Premailex.HTMLInlineStyles.process/3`
 * `Floki` is now optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Requires Elixir 1.14 or higher.
 * Renamed `Premailex.CSSParser.parse_rules/1` to `Premailex.CSSParser.parse_declaration_block/1`
 * `Premailex.CSSParser.parse_declaration_block/1` now does case insensitive, terminal `!important` detection
 * `Premailex.HTMLInlineStyles.process/3` tree traversal performance changed from O(N^2) to O(N)
+* `Premailex.Util.traverse_and_update/2` added
 
 ## v0.3.20 (2025-01-20)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+Thanks for thinking about contributing to Premailex.
+
+## Test suite
+
+Premailex supports several HTML parsers. The parser can be set with the `HTML_PARSER` environment variable:
+
+```bash
+HTML_PARSER=Floki mix test
+```
+
+CI runs the [full matrix](.github/workflows/ci.yml) across Floki, Meeseeks, and LazyHTML.
+
+## Code quality
+
+Elixir formatter, credo and dialyzer are used:
+
+```bash
+mix format --check-formatted
+mix credo --strict
+mix dialyzer
+```
+
+## Benchmarks
+
+Performance-sensitive changes should be checked against the benchmark scripts in `benchmark/`. `HTML_PARSER` is required:
+
+```bash
+HTML_PARSER=Floki mix run benchmark/to_inline_css.exs
+HTML_PARSER=Floki mix run benchmark/to_text.exs
+```
+
+## Submitting a PR
+
+- Write a focused PR description and link related issue if any
+- Update `CHANGELOG.md` under `## Unreleased`
+- If you change behaviour, add or update a test
+- Make sure the parser test matrix passes locally before pushing

--- a/benchmark/benchmark.exs
+++ b/benchmark/benchmark.exs
@@ -1,0 +1,101 @@
+defmodule Benchmark do
+  @moduledoc """
+  Minimal benchmarking utility for Premailex.
+  """
+
+  @doc """
+  Runs a benchmark scenario.
+
+  ## Options
+
+    * `:extra_columns` — extra column definitions inserted between
+      `nodes` and `time (ms)`, in the shape `{name, width,
+      :left | :right}`
+  """
+  def run!(cases, opts \\ []) do
+    extra_columns = Keyword.get(opts, :extra_columns, [])
+
+    columns =
+      [{"name", name_column_width(cases), :left}, {"nodes", 7, :right}] ++
+        extra_columns ++
+        [{"time (ms)", 16, :right}]
+
+    init!(columns)
+
+    Enum.each(cases, fn {labels, run} ->
+      {average, std_dev} = measure_time(fn -> run.() end)
+
+      print_row(columns, labels ++ ["#{format_ms(average)} ± #{format_ms(std_dev)}"])
+    end)
+  end
+
+  defp name_column_width(cases) do
+    cases
+    |> Enum.map(fn {[name | _rest], _run} ->
+      String.length(name)
+    end)
+    |> Enum.max()
+  end
+
+  defp init!(columns) do
+    html_parser =
+      System.get_env("HTML_PARSER") ||
+        raise "Please specify HTML_PARSER environment variable, e.g. `HTML_PARSER=Floki`"
+
+    Application.put_env(
+      :premailex,
+      :html_parser,
+      Module.concat(Premailex.HTMLParser, html_parser)
+    )
+
+    IO.puts("Benchmark with #{inspect(html_parser)} HTML parser:")
+    IO.puts("")
+    IO.puts(row(columns, Enum.map(columns, fn {name, _, _} -> name end)))
+    IO.puts(divider(columns))
+  end
+
+  defp measure_time(fun, iterations \\ 20) do
+    _warmup = fun.()
+
+    times =
+      for _ <- 1..iterations do
+        {us, _} = :timer.tc(fun)
+        us / 1_000
+      end
+
+    average = Enum.sum(times) / iterations
+
+    variance =
+      times
+      |> Enum.map(&((&1 - average) * (&1 - average)))
+      |> Enum.sum()
+      |> Kernel./(iterations)
+
+    {average, :math.sqrt(variance)}
+  end
+
+  defp print_row(columns, values), do: IO.puts(row(columns, values))
+
+  defp format_ms(ms), do: :erlang.float_to_binary(ms, decimals: 2)
+
+  defp row(columns, values) do
+    columns
+    |> Enum.zip(values)
+    |> Enum.map(fn
+      {{_name, width, :left}, value} -> String.pad_trailing(to_string(value), width)
+      {{_name, width, :right}, value} -> String.pad_leading(to_string(value), width)
+    end)
+    |> Enum.intersperse("  ")
+    |> then(&["  " | &1])
+    |> IO.iodata_to_binary()
+  end
+
+  defp divider(columns) do
+    values =
+      Enum.map(columns, fn {_name, width, _align} ->
+        String.duplicate("─", width)
+      end)
+
+    row(columns, values)
+  end
+end

--- a/benchmark/to_inline_css.exs
+++ b/benchmark/to_inline_css.exs
@@ -1,0 +1,216 @@
+Mix.Task.run("app.start")
+Code.require_file("benchmark.exs", __DIR__)
+
+defmodule Benchmark.ToInlineCSS do
+  @moduledoc """
+  Benchmarks `Premailex.to_inline_css/1` across two scenarios.
+
+    * `common` — Matrix spans four email categories:
+
+        Type                        DOM nodes    CSS rules
+        Plain transactional         80–250       20–80
+        Rich transactional          250–800      80–250
+        Standard marketing          600–2000     150–600
+        Heavy marketing/ecommerce   2000–8000+   500–2500+
+
+      `nodes` is the DOM element target count of the generated input; the body
+      is filled with whole sections and then padded with single-node `<p>` chunks
+      until the target is met.
+
+    * `wildcard` — Worst case cascade where every rule matches every tag.
+
+  Run with:
+
+      HTML_PARSER=Floki mix run benchmark/to_inline_css.exs
+  """
+
+  def run do
+    common_cases =
+      for {nodes, rules} <- [{150, 50}, {500, 200}, {1500, 500}, {5000, 1500}] do
+        html = generate_common_html(nodes, rules)
+
+        {
+          ["`to_inline_css/1` - common", nodes, rules],
+          fn -> Premailex.to_inline_css(html) end
+        }
+      end
+
+    wildcard_cases =
+      for nodes <- [1_000, 5_000, 10_000], rules <- [1, 20] do
+        html = generate_wildcard_html(nodes, rules)
+
+        {
+          ["`to_inline_css/1` - wildcard", nodes, rules],
+          fn -> Premailex.to_inline_css(html) end
+        }
+      end
+
+    Benchmark.run!(
+      common_cases ++ wildcard_cases,
+      extra_columns: [{"rules", 5, :right}]
+    )
+  end
+
+  defp generate_common_html(target_nodes, target_rules) do
+    # Note: If the nodes are added or removed in the below HTML the subtracted
+    # number must be updated
+    target_nodes = max(0, target_nodes - 5)
+
+    # Note: If CSS rules are added or removed in the below HTML the subtracted
+    # number must be updated
+    target_rules = max(0, target_rules - 1)
+
+    {body, css} = generate_common_css_html(target_nodes, target_rules, 1, "", "")
+
+    """
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Common email</title>
+        <style>
+          body { font-family: Arial, sans-serif; font-size: 14px; line-height: 22px; color: #333; margin: 0; }
+          #{css}
+        </style>
+      </head>
+      <body>
+        #{body}
+      </body>
+    </html>
+    """
+  end
+
+  defp generate_common_css_html(target_nodes, target_rules, i, "", "")
+       when target_nodes >= 15 and target_rules >= 14 do
+    generate_common_css_html(
+      target_nodes - 15,
+      target_rules - 14,
+      i + 1,
+      common_html_section(i),
+      """
+      table { border-collapse: collapse; }
+      table.outer { width: 600px; }
+      td.cell { padding: 12px; vertical-align: top; }
+      td.cell.header { background: #f4f4f4; }
+      h1 { font-size: 24px; color: #2eac6d; margin: 0 0 8px; }
+      h2 { font-size: 18px; color: #444; margin: 0 0 6px; }
+      p { margin: 0 0 12px; }
+      p.lead { font-size: 16px; font-weight: bold; }
+      a { color: #e95757; text-decoration: underline; }
+      a.button { display: inline-block; padding: 8px 16px; background: #e95757; color: #fff; text-decoration: none; border-radius: 4px; }
+      .muted { color: #888; }
+      .small { font-size: 12px; }
+      ul li { margin-bottom: 4px; }
+      img { display: block; max-width: 100%; }
+      """
+    )
+  end
+
+  defp generate_common_css_html(target_nodes, target_rules, i, body, css)
+       when target_nodes >= 15 do
+    rule_count = min(14, target_rules)
+
+    css =
+      Enum.reduce(1..rule_count//1, css, fn j, css ->
+        "#{css}\n.u-#{i}-#{j} {#{common_html_css_declaration(j)}}"
+      end)
+
+    generate_common_css_html(
+      target_nodes - 15,
+      target_rules - rule_count,
+      i + 1,
+      body <> common_html_section(i),
+      css
+    )
+  end
+
+  defp generate_common_css_html(0, target_rules, i, body, css) when target_rules >= 1 do
+    generate_common_css_html(
+      0,
+      target_rules - 1,
+      i + 1,
+      body,
+      "#{css}\n.no-match-rule-#{i} { color: rgb(#{rem(i * 37, 256)}, #{rem(i * 79, 256)}, #{rem(i * 113, 256)}); }"
+    )
+  end
+
+  defp generate_common_css_html(target_nodes, target_rules, i, body, css)
+       when target_nodes >= 1 do
+    {css, target_rules} =
+      case target_rules > 0 do
+        true -> {"#{css}\np.u-#{i} {#{common_html_css_declaration(i)}}", target_rules - 1}
+        false -> {css, target_rules}
+      end
+
+    body = "#{body}<p class=\"u-#{i}\">Paragraph #{i}</p>\n"
+
+    generate_common_css_html(
+      target_nodes - 1,
+      target_rules,
+      i + 1,
+      body,
+      css
+    )
+  end
+
+  defp generate_common_css_html(0, 0, _i, body, css), do: {body, css}
+
+  defp common_html_section(i) do
+    """
+    <table class="outer u-#{i}-1">
+      <tr class="u-#{i}-2">
+        <td class="cell header u-#{i}-3">
+          <h2 class="u-#{i}-4">Section #{i}</h2>
+          <p class="lead u-#{i}-5">
+            Lead paragraph <a href="#" class="u-#{i}-6">with a link</a> in it.
+          </p>
+          <p class="u-#{i}-7">
+            Some <span class="muted u-#{i}-8">muted text</span> and regular content.
+          </p>
+          <ul class="u-#{i}-9">
+            <li class="u-#{i}-10">Bullet one</li>
+            <li class="u-#{i}-11">Bullet two</li>
+            <li class="u-#{i}-12">Bullet three</li>
+          </ul>
+          <p class="small u-#{i}-13">Footnote about section #{i}.</p>
+          <p>
+            <a href="#" class="button u-#{i}-14">Call to action #{i}</a>
+          </p>
+        </td>
+      </tr>
+    </table>
+    """
+  end
+
+  defp common_html_css_declaration(n) do
+    case rem(n, 3) do
+      0 -> "color: rgb(#{rem(n * 37, 256)}, #{rem(n * 79, 256)}, #{rem(n * 113, 256)});"
+      1 -> "font-size: #{n}px;"
+      2 -> "padding-bottom: #{n}px;"
+    end
+  end
+
+  defp generate_wildcard_html(target_nodes, target_rules) do
+    tags = max(0, target_nodes - 4)
+
+    rules_css =
+      Enum.map_join(1..target_rules//1, "\n", fn i ->
+        "* { prop#{i}: value#{i}; }"
+      end)
+
+    body =
+      Enum.map_join(1..tags//1, "\n", fn i ->
+        ~s(<p data-i="#{i}">Paragraph #{i}</p>)
+      end)
+
+    """
+    <html>
+      <head><style>#{rules_css}</style></head>
+      <body>
+        #{body}
+      </body>
+    </html>
+    """
+  end
+end
+
+Benchmark.ToInlineCSS.run()

--- a/benchmark/to_text.exs
+++ b/benchmark/to_text.exs
@@ -1,0 +1,83 @@
+Mix.Task.run("app.start")
+Code.require_file("benchmark.exs", __DIR__)
+
+defmodule Benchmark.ToText do
+  @moduledoc """
+  Benchmarks `Premailex.to_text/1` across realistic email tree sizes.
+
+  `nodes` is the DOM element target count of the generated input; the body is
+  filled with whole sections and then padded with single-node `<p>` chunks
+  until the target is met.
+
+  Run with:
+
+      HTML_PARSER=Floki mix run benchmark/to_text.exs
+  """
+
+  def run do
+    cases =
+      for n <- [50, 150, 500, 1_000] do
+        html = generate_html(n)
+
+        {
+          ["`to_text/1`", n],
+          fn -> Premailex.to_text(html) end
+        }
+      end
+
+    Benchmark.run!(cases)
+  end
+
+  defp generate_html(target_nodes) do
+    target_nodes = max(0, target_nodes - 4)
+
+    """
+    <!DOCTYPE html>
+    <html>
+      <head><title>Common email</title></head>
+      <body>
+        #{generate_section_html(target_nodes, 1, "")}
+      </body>
+    </html>
+    """
+  end
+
+  defp generate_section_html(target_nodes, i, acc) when target_nodes >= 19 do
+    generate_section_html(
+      target_nodes - 19,
+      i + 1,
+      """
+      #{acc}
+      <table>
+        <tr>
+          <td>
+            <h2>Section #{i}</h2>
+            <p class="lead">Lead paragraph <a href="https://example.com/#{i}">with a link</a> in it.</p>
+            <p>Some <span>inline</span> text and more regular content for section #{i}.</p>
+            <ul><li>Bullet one</li><li>Bullet two</li><li>Bullet three</li></ul>
+            <ol><li>First</li><li>Second</li></ol>
+            <hr>
+            <p class="small">Footnote about section #{i}.</p>
+            <p><a href="#" class="button">Call to action #{i}</a></p>
+          </td>
+        </tr>
+      </table>
+      """
+    )
+  end
+
+  defp generate_section_html(target_nodes, i, acc) when target_nodes >= 1 do
+    generate_section_html(
+      target_nodes - 1,
+      i + 1,
+      """
+      #{acc}
+      <p>Paragraph #{i}</p>
+      """
+    )
+  end
+
+  defp generate_section_html(_target_nodes, _i, acc), do: acc
+end
+
+Benchmark.ToText.run()

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -129,18 +129,44 @@ defmodule Premailex.HTMLInlineStyles do
          %{selector: selector, declarations: declarations, specificity: specificity},
          tree
        ) do
-    tree
-    |> HTMLParser.all(selector)
-    |> Enum.reduce(tree, &update_style_for_html_tree(&2, &1, declarations, specificity))
-  end
-
-  defp update_style_for_html_tree(tree, needle, declarations, specificity) do
-    Util.traverse_until_first(
+    update_selector_matches_in_tree(
       tree,
-      needle,
+      selector,
       &update_style_for_element(&1, declarations, specificity)
     )
   end
+
+  # `HTMLParser.all/2` arrive in document order, so a single depth-first walk
+  # consumes them via the `[^element | rest]` head match with O(1) per check,
+  # O(N) walk worst case.
+
+  defp update_selector_matches_in_tree(tree, selector, fun) do
+    tree
+    |> HTMLParser.all(selector)
+    |> case do
+      [] -> {tree, []}
+      matches -> update_node_matches_in_tree(tree, matches, fun)
+    end
+    |> elem(0)
+  end
+
+  defp update_node_matches_in_tree(nodes, matches, fun) when is_list(nodes),
+    do: Enum.map_reduce(nodes, matches, &update_node_matches_in_tree(&1, &2, fun))
+
+  defp update_node_matches_in_tree({_, _, _} = element, [element | rest], fun) do
+    {tag, attrs, children} = fun.(element)
+    {updated_children, remaining} = update_node_matches_in_tree(children, rest, fun)
+
+    {{tag, attrs, updated_children}, remaining}
+  end
+
+  defp update_node_matches_in_tree({tag, attrs, children}, matches, fun) do
+    {updated_children, remaining} = update_node_matches_in_tree(children, matches, fun)
+
+    {{tag, attrs, updated_children}, remaining}
+  end
+
+  defp update_node_matches_in_tree(other, matches, _fun), do: {other, matches}
 
   defp update_style_for_element({name, attrs, children}, declarations, specificity) do
     style =
@@ -175,13 +201,7 @@ defmodule Premailex.HTMLInlineStyles do
   end
 
   defp normalize_styles(tree) do
-    tree
-    |> HTMLParser.all("[style]")
-    |> Enum.reduce(tree, &merge_styles(&2, &1))
-  end
-
-  defp merge_styles(tree, needle) do
-    Util.traverse_until_first(tree, needle, &merge_style/1)
+    update_selector_matches_in_tree(tree, "[style]", &merge_style/1)
   end
 
   defp merge_style({name, attrs, children}) do

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -49,8 +49,7 @@ defmodule Premailex.HTMLInlineStyles do
     optimize_options = Keyword.take(options, [:css_selector])
 
     css_rules
-    |> apply_styles(tree)
-    |> normalize_styles()
+    |> apply_rules(tree)
     |> optimize(optimize_steps, optimize_options)
     |> remove_empty_comments()
     |> HTMLParser.to_string()
@@ -64,7 +63,7 @@ defmodule Premailex.HTMLInlineStyles do
     |> Enum.reduce([], &Enum.concat(&1, &2))
   end
 
-  defp apply_styles(styles, tree) do
+  defp apply_rules(rules, tree) do
     hidden_elements =
       tree
       |> HTMLParser.all("head")
@@ -79,8 +78,9 @@ defmodule Premailex.HTMLInlineStyles do
         Util.traverse_until_first(tree, hidden_element, fn _element -> placeholder end)
       end)
 
-    styles
-    |> Enum.reduce(visible_tree, &add_rules_to_html_tree(&1, &2))
+    visible_tree
+    |> match_rules_to_elements(rules)
+    |> apply_matched_rules(visible_tree)
     |> Util.traverse("premailex", fn {"premailex", attrs, _children} ->
       {"data-index", index} = Enum.find(attrs, &(elem(&1, 0) == "data-index"))
 
@@ -88,6 +88,68 @@ defmodule Premailex.HTMLInlineStyles do
 
       hidden_element
     end)
+  end
+
+  defp match_rules_to_elements(tree, rules) do
+    Enum.reduce(rules, %{}, fn rule, acc ->
+      tree
+      |> HTMLParser.all(rule.selector)
+      |> Enum.reduce(acc, &prepend_deduped_rule(&2, &1, rule))
+    end)
+  end
+
+  # NOTE: This match is not right as it doesn't account for identical elements.
+  # A selector like `tr:nth-child(even)` would match identical siblings. A fix
+  # would be to have the HTML parser adapters do positional selector
+  # evaluation.
+  defp prepend_deduped_rule(acc, element, rule) do
+    Map.update(acc, element, [rule], fn
+      [^rule | _] = list -> list
+      list -> [rule | list]
+    end)
+  end
+
+  defp apply_matched_rules(matches, tree) when map_size(matches) == 0, do: tree
+
+  defp apply_matched_rules(matches, tree) do
+    Util.traverse_and_update(tree, fn element ->
+      case Map.get(matches, element) do
+        nil -> element
+        rules -> apply_inline_style(element, rules)
+      end
+    end)
+  end
+
+  defp apply_inline_style({name, attrs, children}, rules) do
+    attrs =
+      attrs
+      |> get_inline_css_rule()
+      |> List.wrap()
+      |> Kernel.++(Enum.reverse(rules))
+      |> CSSParser.merge()
+      |> case do
+        [] ->
+          attrs
+
+        declarations ->
+          List.keystore(attrs, "style", 0, {"style", CSSParser.to_string(declarations)})
+      end
+
+    {name, attrs, children}
+  end
+
+  defp get_inline_css_rule(attrs) do
+    case List.keyfind(attrs, "style", 0) do
+      nil ->
+        nil
+
+      {"style", style} ->
+        %{
+          selector: "",
+          declarations: CSSParser.parse_declaration_block(style),
+          specificity: {1, 0, 0, 0}
+        }
+    end
   end
 
   defp load_css({"style", _, content}) do
@@ -123,110 +185,6 @@ defmodule Premailex.HTMLInlineStyles do
     )
 
     nil
-  end
-
-  defp add_rules_to_html_tree(
-         %{selector: selector, declarations: declarations, specificity: specificity},
-         tree
-       ) do
-    update_selector_matches_in_tree(
-      tree,
-      selector,
-      &update_style_for_element(&1, declarations, specificity)
-    )
-  end
-
-  # `HTMLParser.all/2` arrive in document order, so a single depth-first walk
-  # consumes them via the `[^element | rest]` head match with O(1) per check,
-  # O(N) walk worst case.
-
-  defp update_selector_matches_in_tree(tree, selector, fun) do
-    tree
-    |> HTMLParser.all(selector)
-    |> case do
-      [] -> {tree, []}
-      matches -> update_node_matches_in_tree(tree, matches, fun)
-    end
-    |> elem(0)
-  end
-
-  defp update_node_matches_in_tree(nodes, matches, fun) when is_list(nodes),
-    do: Enum.map_reduce(nodes, matches, &update_node_matches_in_tree(&1, &2, fun))
-
-  defp update_node_matches_in_tree({_, _, _} = element, [element | rest], fun) do
-    {tag, attrs, children} = fun.(element)
-    {updated_children, remaining} = update_node_matches_in_tree(children, rest, fun)
-
-    {{tag, attrs, updated_children}, remaining}
-  end
-
-  defp update_node_matches_in_tree({tag, attrs, children}, matches, fun) do
-    {updated_children, remaining} = update_node_matches_in_tree(children, matches, fun)
-
-    {{tag, attrs, updated_children}, remaining}
-  end
-
-  defp update_node_matches_in_tree(other, matches, _fun), do: {other, matches}
-
-  defp update_style_for_element({name, attrs, children}, declarations, specificity) do
-    style =
-      attrs
-      |> Enum.into(%{})
-      |> Map.get("style", nil)
-      |> set_inline_style_specificity()
-      |> add_styles_with_specificity(declarations, specificity)
-
-    {name, put_style_attr(attrs, style), children}
-  end
-
-  defp put_style_attr(attrs, style) do
-    List.keystore(attrs, "style", 0, {"style", style})
-  end
-
-  defp set_inline_style_specificity(nil), do: ""
-  defp set_inline_style_specificity("[SPEC=" <> _rest = style), do: style
-
-  defp set_inline_style_specificity(style),
-    do: "[SPEC=#{format_specificity({1, 0, 0, 0})}[#{style}]]"
-
-  defp add_styles_with_specificity(style, declarations, specificity) do
-    "#{style}[SPEC=#{format_specificity(specificity)}[#{CSSParser.to_string(declarations)}]]"
-  end
-
-  defp format_specificity({a, b, c, d}), do: "#{a}.#{b}.#{c}.#{d}"
-
-  defp parse_specificity(str) do
-    [a, b, c, d] = str |> String.split(".") |> Enum.map(&String.to_integer/1)
-    {a, b, c, d}
-  end
-
-  defp normalize_styles(tree) do
-    update_selector_matches_in_tree(tree, "[style]", &merge_style/1)
-  end
-
-  defp merge_style({name, attrs, children}) do
-    current_style =
-      attrs
-      |> Enum.into(%{})
-      |> Map.get("style")
-
-    style =
-      ~r/\[SPEC\=(\d+\.\d+\.\d+\.\d+)\[(.[^\]\]]*)\]\]/
-      |> Regex.scan(current_style)
-      |> Enum.map(fn [_, specificity, declaration_block] ->
-        %{
-          specificity: parse_specificity(specificity),
-          declarations: CSSParser.parse_declaration_block(declaration_block)
-        }
-      end)
-      |> CSSParser.merge()
-      |> CSSParser.to_string()
-      |> case do
-        "" -> current_style
-        style -> style
-      end
-
-    {name, put_style_attr(attrs, style), children}
   end
 
   defp optimize(tree, steps, options) when is_atom(steps), do: optimize(tree, [steps], options)

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -49,7 +49,7 @@ defmodule Premailex.HTMLInlineStyles do
     optimize_options = Keyword.take(options, [:css_selector])
 
     css_rules
-    |> apply_rules(tree)
+    |> apply_css_rules(tree)
     |> optimize(optimize_steps, optimize_options)
     |> remove_empty_comments()
     |> HTMLParser.to_string()
@@ -58,78 +58,76 @@ defmodule Premailex.HTMLInlineStyles do
   defp load_styles(tree, css_selector) do
     tree
     |> HTMLParser.all(css_selector)
-    |> Enum.map(&load_css(&1))
-    |> Enum.filter(&(!is_nil(&1)))
+    |> Enum.map(&load_css/1)
+    |> Enum.reject(&is_nil/1)
     |> Enum.reduce([], &Enum.concat(&1, &2))
   end
 
-  defp apply_rules(rules, tree) do
-    hidden_elements =
+  defp apply_css_rules(css_rules, tree) do
+    hidden_heads =
       tree
       |> HTMLParser.all("head")
-      |> Enum.reduce([], fn element, acc ->
-        index = to_string(length(acc))
-
-        acc ++ [{index, element, {"premailex", [{"data-index", index}], []}}]
+      |> Enum.with_index()
+      |> Map.new(fn {head, i} ->
+        {Integer.to_string(i), head}
       end)
 
     visible_tree =
-      Enum.reduce(hidden_elements, tree, fn {_index, hidden_element, placeholder}, tree ->
-        Util.traverse_until_first(tree, hidden_element, fn _element -> placeholder end)
+      Enum.reduce(hidden_heads, tree, fn {index, head}, acc ->
+        Util.traverse_until_first(acc, head, fn _ ->
+          {"premailex", [{"data-index", index}], []}
+        end)
       end)
 
     visible_tree
-    |> match_rules_to_elements(rules)
-    |> apply_matched_rules(visible_tree)
+    |> match_css_rules_to_elements(css_rules)
+    |> apply_matched_css_rules(visible_tree)
     |> Util.traverse("premailex", fn {"premailex", attrs, _children} ->
-      {"data-index", index} = Enum.find(attrs, &(elem(&1, 0) == "data-index"))
+      {"data-index", index} = List.keyfind(attrs, "data-index", 0)
 
-      {_index, hidden_element, _replacement} = Enum.find(hidden_elements, &(elem(&1, 0) == index))
-
-      hidden_element
+      Map.fetch!(hidden_heads, index)
     end)
   end
 
-  defp match_rules_to_elements(tree, rules) do
-    Enum.reduce(rules, %{}, fn rule, acc ->
+  defp match_css_rules_to_elements(tree, css_rules) do
+    Enum.reduce(css_rules, %{}, fn rule, acc ->
       tree
       |> HTMLParser.all(rule.selector)
-      |> Enum.reduce(acc, &prepend_deduped_rule(&2, &1, rule))
+      |> Enum.reduce(acc, &prepend_deduped_css_rule(&2, &1, rule))
     end)
   end
 
-  # NOTE: This match is not right as it doesn't account for identical elements.
   # A selector like `tr:nth-child(even)` would match identical siblings. A fix
   # would be to have the HTML parser adapters do positional selector
   # evaluation.
-  defp prepend_deduped_rule(acc, element, rule) do
+  defp prepend_deduped_css_rule(acc, element, rule) do
     Map.update(acc, element, [rule], fn
       [^rule | _] = list -> list
       list -> [rule | list]
     end)
   end
 
-  defp apply_matched_rules(matches, tree) when map_size(matches) == 0, do: tree
+  defp apply_matched_css_rules(css_rules_map, tree) when map_size(css_rules_map) == 0, do: tree
 
-  defp apply_matched_rules(matches, tree) do
-    merged_matches =
-      matches
+  defp apply_matched_css_rules(css_rules_map, tree) do
+    declarations_by_rules =
+      css_rules_map
       |> Map.values()
       |> Enum.uniq()
       |> Map.new(fn rules -> {rules, CSSParser.merge(rules)} end)
 
     Util.traverse_and_update(tree, fn element ->
-      case Map.get(matches, element) do
+      case Map.get(css_rules_map, element) do
         nil -> element
-        rules -> apply_inline_style(element, rules, merged_matches)
+        rules -> put_inline_style(element, rules, declarations_by_rules)
       end
     end)
   end
 
-  defp apply_inline_style({name, attrs, children}, rules, merged_matches) do
+  defp put_inline_style({name, attrs, children}, rules, declarations_by_rules) do
     attrs =
       attrs
-      |> merge_inlined_css_rule(merged_matches, rules)
+      |> merge_inlined_style(declarations_by_rules, rules)
       |> case do
         [] ->
           attrs
@@ -141,10 +139,10 @@ defmodule Premailex.HTMLInlineStyles do
     {name, attrs, children}
   end
 
-  defp merge_inlined_css_rule(attrs, merged_matches, rules) do
+  defp merge_inlined_style(attrs, declarations_by_rules, rules) do
     case List.keyfind(attrs, "style", 0) do
       nil ->
-        Map.fetch!(merged_matches, rules)
+        Map.fetch!(declarations_by_rules, rules)
 
       {"style", style} ->
         CSSParser.merge([

--- a/lib/premailex/html_inline_styles.ex
+++ b/lib/premailex/html_inline_styles.ex
@@ -112,21 +112,24 @@ defmodule Premailex.HTMLInlineStyles do
   defp apply_matched_rules(matches, tree) when map_size(matches) == 0, do: tree
 
   defp apply_matched_rules(matches, tree) do
+    merged_matches =
+      matches
+      |> Map.values()
+      |> Enum.uniq()
+      |> Map.new(fn rules -> {rules, CSSParser.merge(rules)} end)
+
     Util.traverse_and_update(tree, fn element ->
       case Map.get(matches, element) do
         nil -> element
-        rules -> apply_inline_style(element, rules)
+        rules -> apply_inline_style(element, rules, merged_matches)
       end
     end)
   end
 
-  defp apply_inline_style({name, attrs, children}, rules) do
+  defp apply_inline_style({name, attrs, children}, rules, merged_matches) do
     attrs =
       attrs
-      |> get_inline_css_rule()
-      |> List.wrap()
-      |> Kernel.++(Enum.reverse(rules))
-      |> CSSParser.merge()
+      |> merge_inlined_css_rule(merged_matches, rules)
       |> case do
         [] ->
           attrs
@@ -138,17 +141,20 @@ defmodule Premailex.HTMLInlineStyles do
     {name, attrs, children}
   end
 
-  defp get_inline_css_rule(attrs) do
+  defp merge_inlined_css_rule(attrs, merged_matches, rules) do
     case List.keyfind(attrs, "style", 0) do
       nil ->
-        nil
+        Map.fetch!(merged_matches, rules)
 
       {"style", style} ->
-        %{
-          selector: "",
-          declarations: CSSParser.parse_declaration_block(style),
-          specificity: {1, 0, 0, 0}
-        }
+        CSSParser.merge([
+          %{
+            selector: "",
+            declarations: CSSParser.parse_declaration_block(style),
+            specificity: {1, 0, 0, 0}
+          }
+          | rules
+        ])
     end
   end
 

--- a/lib/premailex/html_to_plain_text.ex
+++ b/lib/premailex/html_to_plain_text.ex
@@ -135,13 +135,13 @@ defmodule Premailex.HTMLToPlainText do
 
   defp ordered_list_items({_, _, items}) do
     items
-    |> Util.traverse_reduce("li", &ordered_list_item(&1, &2))
-    |> elem(0)
+    |> Enum.with_index(1)
+    |> Enum.map(fn {item, n} -> Util.traverse(item, "li", &ordered_list_item(&1, n)) end)
     |> join_binaries("")
   end
 
-  defp ordered_list_item({_, _, content}, acc) do
-    "#{acc + 1}. " <> HTMLParser.text(content) <> "\n"
+  defp ordered_list_item({_, _, content}, n) do
+    "#{n}. " <> HTMLParser.text(content) <> "\n"
   end
 
   defp tables(tree), do: Util.traverse(tree, "table", &table(&1))

--- a/lib/premailex/util.ex
+++ b/lib/premailex/util.ex
@@ -109,4 +109,30 @@ defmodule Premailex.Util do
       tree -> tree
     end
   end
+
+  @doc """
+  Traverses tree calling the function on every element and replacing each with
+  the result.
+
+  Children of the returned element are walked again, so the function can
+  produce new subtrees that themselves contain matches.
+
+  ## Examples
+
+      iex> Premailex.Util.traverse_and_update({"div", [], [{"p", [], ["hi"]}]}, fn {tag, attrs, children} -> {tag, [{"class", "x"} | attrs], children} end)
+      {"div", [{"class", "x"}], [{"p", [{"class", "x"}], ["hi"]}]}
+  """
+  @spec traverse_and_update(html_tree(), (html_element() -> html_element())) :: html_tree()
+  def traverse_and_update(tree, fun), do: do_traverse_and_update(tree, fun)
+
+  defp do_traverse_and_update(children, fun) when is_list(children),
+    do: Enum.map(children, &do_traverse_and_update(&1, fun))
+
+  defp do_traverse_and_update({_, _, _} = element, fun) do
+    {tag, attrs, children} = fun.(element)
+
+    {tag, attrs, do_traverse_and_update(children, fun)}
+  end
+
+  defp do_traverse_and_update(other, _fun), do: other
 end

--- a/lib/premailex/util.ex
+++ b/lib/premailex/util.ex
@@ -31,47 +31,53 @@ defmodule Premailex.Util do
   @spec traverse(html_tree(), needle() | [needle()], (html_node() -> html_node())) :: html_tree()
   @spec traverse(html_tree(), needle() | [needle()], (html_node() -> {:halt, html_node()})) ::
           html_tree() | {:halt, html_tree()}
-  def traverse(tree, needles, fun) when is_list(needles),
-    do: Enum.reduce(needles, tree, &traverse(&2, &1, fun))
+  def traverse(tree, needle_or_needles, fun),
+    do: do_traverse(tree, List.wrap(needle_or_needles), fun)
 
-  def traverse(children, needle, fun) when is_list(children) do
+  defp do_traverse(children, needles, fun) when is_list(children) do
     children
-    |> Enum.map_reduce(:ok, &maybe_traverse({&1, needle, fun}, &2))
+    |> Enum.map_reduce(:ok, &maybe_traverse({&1, needles, fun}, &2))
     |> case do
       {children, :halt} -> {:halt, children}
       {children, :ok} -> children
     end
   end
 
-  def traverse(text, _, _) when is_binary(text), do: text
+  defp do_traverse(text, _needles, _fun) when is_binary(text), do: text
 
-  def traverse({:comment, _comment} = element, :comment, fun), do: fun.(element)
-
-  def traverse({name, attrs, children} = element, needle, fun) do
-    cond do
-      needle == name -> fun.(element)
-      needle == element -> fun.(element)
-      true -> handle_traversed({name, attrs, children}, needle, fun)
+  defp do_traverse({:comment, _comment} = element, needles, fun) do
+    case :comment in needles do
+      true -> fun.(element)
+      false -> element
     end
   end
 
-  def traverse(element, _, _), do: element
+  defp do_traverse({name, attrs, children} = element, needles, fun) do
+    cond do
+      name in needles ->
+        fun.(element)
 
-  defp maybe_traverse({element, needle, fun}, :ok) do
-    case traverse(element, needle, fun) do
+      element in needles ->
+        fun.(element)
+
+      true ->
+        case do_traverse(children, needles, fun) do
+          {:halt, children} -> {:halt, {name, attrs, children}}
+          children -> {name, attrs, children}
+        end
+    end
+  end
+
+  defp do_traverse(other, _needles, _fun), do: other
+
+  defp maybe_traverse({element, needles, fun}, :ok) do
+    case do_traverse(element, needles, fun) do
       {:halt, children} -> {children, :halt}
       children -> {children, :ok}
     end
   end
 
-  defp maybe_traverse({element, _needle, _fun}, :halt), do: {element, :halt}
-
-  defp handle_traversed({name, attrs, children}, needle, fun) do
-    case traverse(children, needle, fun) do
-      {:halt, children} -> {:halt, {name, attrs, children}}
-      children -> {name, attrs, children}
-    end
-  end
+  defp maybe_traverse({element, _needles, _fun}, :halt), do: {element, :halt}
 
   @doc """
   Traverses each element in `children`, calling `fun.(element, index)` for any

--- a/lib/premailex/util.ex
+++ b/lib/premailex/util.ex
@@ -14,8 +14,8 @@ defmodule Premailex.Util do
   Traverses tree searching for needle, and will call provided function on
   any occurances.
 
-  If the function returns `{:halt, any}`, traverse will stop, and result will
-  be `{:halt, html_tree}`.
+  The tree will be traversed depth-first, and the function will be called on
+  every node matching a needle, replacing each with the result.
 
   ## Examples
 
@@ -29,19 +29,11 @@ defmodule Premailex.Util do
       {"div", [], [{:comment, "Updated"}, {"p", [], ["Paragraph"]}]}
   """
   @spec traverse(html_tree(), needle() | [needle()], (html_node() -> html_node())) :: html_tree()
-  @spec traverse(html_tree(), needle() | [needle()], (html_node() -> {:halt, html_node()})) ::
-          html_tree() | {:halt, html_tree()}
   def traverse(tree, needle_or_needles, fun),
     do: do_traverse(tree, List.wrap(needle_or_needles), fun)
 
-  defp do_traverse(children, needles, fun) when is_list(children) do
-    children
-    |> Enum.map_reduce(:ok, &maybe_traverse({&1, needles, fun}, &2))
-    |> case do
-      {children, :halt} -> {:halt, children}
-      {children, :ok} -> children
-    end
-  end
+  defp do_traverse(children, needles, fun) when is_list(children),
+    do: Enum.map(children, &do_traverse(&1, needles, fun))
 
   defp do_traverse(text, _needles, _fun) when is_binary(text), do: text
 
@@ -54,54 +46,19 @@ defmodule Premailex.Util do
 
   defp do_traverse({name, attrs, children} = element, needles, fun) do
     cond do
-      name in needles ->
-        fun.(element)
-
-      element in needles ->
-        fun.(element)
-
-      true ->
-        case do_traverse(children, needles, fun) do
-          {:halt, children} -> {:halt, {name, attrs, children}}
-          children -> {name, attrs, children}
-        end
+      name in needles -> fun.(element)
+      element in needles -> fun.(element)
+      true -> {name, attrs, do_traverse(children, needles, fun)}
     end
   end
 
   defp do_traverse(other, _needles, _fun), do: other
 
-  defp maybe_traverse({element, needles, fun}, :ok) do
-    case do_traverse(element, needles, fun) do
-      {:halt, children} -> {children, :halt}
-      children -> {children, :ok}
-    end
-  end
-
-  defp maybe_traverse({element, _needles, _fun}, :halt), do: {element, :halt}
-
-  @doc """
-  Traverses each element in `children`, calling `fun.(element, index)` for any
-  occurrence of `needle`, where `index` is the zero-based position of the
-  element in `children`. Returns `{children, count}` where `count` is the total
-  number of children traversed.
-
-  ## Examples
-
-      iex> Premailex.Util.traverse_reduce([{"p", [], ["First paragraph"]}, {"p", [], ["Second paragraph"]}], "p", fn({name, attrs, _children}, acc) -> {name, attrs, ["Updated " <> to_string(acc)]} end)
-      {[{"p", [], ["Updated 0"]}, {"p", [], ["Updated 1"]}], 2}
-  """
-  @spec traverse_reduce([html_node()], needle(), (html_node(), non_neg_integer() -> html_node())) ::
-          {[html_node()], non_neg_integer()}
-  def traverse_reduce(children, needle, fun) when is_list(children),
-    do:
-      Enum.map_reduce(
-        children,
-        0,
-        &{traverse(&1, needle, fn element -> fun.(element, &2) end), &2 + 1}
-      )
-
   @doc """
   Traverses tree until first match for needle.
+
+  The tree will be traversed depth-first, and the function will be called on
+  the first node matching a needle, replacing it with the result.
 
   ## Examples
 
@@ -110,11 +67,52 @@ defmodule Premailex.Util do
   """
   @spec traverse_until_first(html_tree(), needle(), (html_node() -> html_node())) :: html_tree()
   def traverse_until_first(tree, needle, fun) do
-    case traverse(tree, needle, &{:halt, fun.(&1)}) do
+    case do_traverse_until_first(tree, needle, fun) do
       {:halt, tree} -> tree
       tree -> tree
     end
   end
+
+  defp do_traverse_until_first(children, needle, fun) when is_list(children) do
+    children
+    |> Enum.reduce({:cont, []}, fn
+      child, {:cont, acc} ->
+        case do_traverse_until_first(child, needle, fun) do
+          {:halt, result} -> {:halt, [result | acc]}
+          other -> {:cont, [other | acc]}
+        end
+
+      child, {:halt, acc} ->
+        {:halt, [child | acc]}
+    end)
+    |> case do
+      {:halt, acc} -> {:halt, Enum.reverse(acc)}
+      {:cont, acc} -> Enum.reverse(acc)
+    end
+  end
+
+  defp do_traverse_until_first(text, _needle, _fun) when is_binary(text), do: text
+
+  defp do_traverse_until_first({:comment, _comment} = element, :comment, fun) do
+    {:halt, fun.(element)}
+  end
+
+  defp do_traverse_until_first({name, _attrs, _children} = element, name, fun) do
+    {:halt, fun.(element)}
+  end
+
+  defp do_traverse_until_first({_, _, _} = element, element, fun) do
+    {:halt, fun.(element)}
+  end
+
+  defp do_traverse_until_first({name, attrs, children}, needle, fun) do
+    case do_traverse_until_first(children, needle, fun) do
+      {:halt, new_children} -> {:halt, {name, attrs, new_children}}
+      new_children -> {name, attrs, new_children}
+    end
+  end
+
+  defp do_traverse_until_first(other, _needle, _fun), do: other
 
   @doc """
   Traverses tree calling the function on every element and replacing each with


### PR DESCRIPTION
Resolves #90. There was a lot of poor traversal logic. For heavy wildcard use it should easily be a 100x+ speedup.

## Before

#### `to_inline_css/1`

| name                      | nodes | rules | time (ms)         |
|---------------------------|-------|-------|-------------------|
| `to_inline_css/1` - common   |   150 |    50 |      7.27 ± 0.23  |
| `to_inline_css/1` - common   |   500 |   200 |     66.17 ± 2.02  |
| `to_inline_css/1` - common   |  1500 |   500 |    459.98 ± 4.46  |
| `to_inline_css/1` - common   |  5000 |  1500 |  6507.16 ± 428.79 |
| `to_inline_css/1` - wildcard |  1000 |     1 |    215.85 ± 3.73  |
| `to_inline_css/1` - wildcard |  1000 |    20 |   2227.49 ± 23.18 |
| `to_inline_css/1` - wildcard |  5000 |     1 |  5094.40 ± 203.21 |
| `to_inline_css/1` - wildcard |  5000 |    20 | 56366.88 ± 684.33 |
| `to_inline_css/1` - wildcard | 10000 |     1 | 19606.91 ± 389.65 |
| `to_inline_css/1` - wildcard | 10000 |    20 |206035.92 ± 5348.14|

#### `to_text/1`

| name        | nodes | time (ms)      |
|-------------|-------|----------------|
| `to_text/1` |    50 | 0.20 ± 0.02    |
| `to_text/1` |   150 | 0.59 ± 0.04    |
| `to_text/1` |   500 | 2.00 ± 0.12    |
| `to_text/1` |  1000 | 3.98 ± 0.20    |


## After

#### `to_inline_css/1`

| name                      | nodes | rules | time (ms)        |
|---------------------------|-------|-------|------------------|
| `to_inline_css/1` - common   |   150 |    50 |    2.01 ± 0.15  |
| `to_inline_css/1` - common   |   500 |   200 |   21.03 ± 0.66  |
| `to_inline_css/1` - common   |  1500 |   500 |  130.64 ± 3.40  |
| `to_inline_css/1` - common   |  5000 |  1500 | 1407.02 ± 29.12 |
| `to_inline_css/1` - wildcard |  1000 |     1 |    4.00 ± 0.21  |
| `to_inline_css/1` - wildcard |  1000 |    20 |   17.33 ± 0.80  |
| `to_inline_css/1` - wildcard |  5000 |     1 |   11.01 ± 0.51  |
| `to_inline_css/1` - wildcard |  5000 |    20 |   89.41 ± 4.97  |
| `to_inline_css/1` - wildcard | 10000 |     1 |   44.15 ± 1.62  |
| `to_inline_css/1` - wildcard | 10000 |    20 |  219.32 ± 15.91 |

#### `to_text/1`

| name        | nodes | time (ms)      |
|-------------|-------|----------------|
| `to_text/1` |    50 | 0.16 ± 0.03    |
| `to_text/1` |   150 | 0.50 ± 0.01    |
| `to_text/1` |   500 | 1.74 ± 0.09    |
| `to_text/1` |  1000 | 3.51 ± 0.11    |