### PR TITLE
Preserve source order of matching selector items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * `Premailex.HTMLParser.Meeseeks.parse/1` no longer raises `MatchError` for document fragments that contains head level content such as `<style>`, `<meta>`, `<link>`, or `<title>`
+* `Premailex.DOM.traverse_with_matching_items/3` now passes matching selector items to the callback in the order they were given in, so declarations of equal specificity are again resolved by source order
 
 ## v1.0.0 (2026-05-24)
 

--- a/lib/premailex/dom.ex
+++ b/lib/premailex/dom.ex
@@ -185,9 +185,15 @@ defmodule Premailex.DOM do
   defp build_selector_items_lookup_table(selector_items) do
     initial = %{by_tag: %{}, by_class: %{}, by_id: %{}, universal: []}
 
-    Enum.reduce(selector_items, initial, fn selector_item, selector_items_table ->
+    selector_items
+    |> Enum.with_index()
+    |> Enum.reduce(initial, fn {selector_item, index}, selector_items_table ->
       compiled_groups = compile_selector_groups(selector_item.selector)
-      selector_item = Map.put(selector_item, :compiled_selector_groups, compiled_groups)
+
+      selector_item =
+        selector_item
+        |> Map.put(:compiled_selector_groups, compiled_groups)
+        |> Map.put(:source_index, index)
 
       Enum.reduce(
         compiled_groups,
@@ -278,6 +284,7 @@ defmodule Premailex.DOM do
                 &matches_selector_group?(context, &1, ancestors)
               )
             end)
+            |> restore_source_order()
             |> case do
               [] -> {tag, attrs, traversed_children}
               matched_items -> fun.({tag, attrs, traversed_children}, matched_items)
@@ -352,6 +359,22 @@ defmodule Premailex.DOM do
         |> :binary.split(" ", [:global])
         |> Enum.reduce(acc, &prepend_selector_items(&2, by_class, &1))
     end
+  end
+
+  # The lookup table buckets selector items by tag, id, and class, so matches
+  # are gathered per bucket rather than in the order the items were given in.
+  # Consumers rely on that order, e.g. the CSS cascade resolves declarations of
+  # equal specificity by source order, so it's restored here.
+  #
+  # A selector item is registered once per selector group, so it can be matched
+  # more than once. Duplicates are consecutive after the sort and dropped.
+  defp restore_source_order([]), do: []
+  defp restore_source_order([_selector_item] = selector_items), do: selector_items
+
+  defp restore_source_order(selector_items) do
+    selector_items
+    |> Enum.sort_by(& &1.source_index)
+    |> Enum.dedup_by(& &1.source_index)
   end
 
   defp matches_selector_group?(_context, [], _ancestors), do: false

--- a/test/premailex/html_inline_styles_test.exs
+++ b/test/premailex/html_inline_styles_test.exs
@@ -158,6 +158,74 @@ defmodule Premailex.HTMLInlineStylesTest do
              |> Premailex.to_html() == ~s(<p class="lead" style="color: blue;">Text</p>)
     end
 
+    test "with equal specificity rules resolves by source order" do
+      tree = Premailex.parse(~s(<p class="a b">Text</p>))
+
+      assert tree
+             |> HTMLInlineStyles.process(
+               CSSParser.parse(".a { color: red; } .b { color: blue; }")
+             )
+             |> Premailex.to_html() == ~s(<p class="a b" style="color: blue;">Text</p>)
+
+      assert tree
+             |> HTMLInlineStyles.process(
+               CSSParser.parse(".b { color: blue; } .a { color: red; }")
+             )
+             |> Premailex.to_html() == ~s(<p class="a b" style="color: red;">Text</p>)
+    end
+
+    test "with equal specificity rules ignores the order of the class attribute" do
+      css_rules = CSSParser.parse(".a { color: red; } .b { color: blue; }")
+
+      assert ~s(<p class="a b">Text</p>)
+             |> Premailex.parse()
+             |> HTMLInlineStyles.process(css_rules)
+             |> Premailex.to_html() == ~s(<p class="a b" style="color: blue;">Text</p>)
+
+      assert ~s(<p class="b a">Text</p>)
+             |> Premailex.parse()
+             |> HTMLInlineStyles.process(css_rules)
+             |> Premailex.to_html() == ~s(<p class="b a" style="color: blue;">Text</p>)
+    end
+
+    test "with duplicate selector resolves by source order" do
+      tree = Premailex.parse(~s(<p class="a">Text</p>))
+
+      assert tree
+             |> HTMLInlineStyles.process(
+               CSSParser.parse(".a { color: red; } .a { color: blue; }")
+             )
+             |> Premailex.to_html() == ~s(<p class="a" style="color: blue;">Text</p>)
+    end
+
+    test "with equal specificity rules in different selector types" do
+      # `.a` is matched by class and `[data-x]` by the universal bucket, both
+      # with a specificity of {0, 0, 1, 0}
+      tree = Premailex.parse(~s(<p class="a" data-x="1">Text</p>))
+
+      assert tree
+             |> HTMLInlineStyles.process(
+               CSSParser.parse(".a { color: red; } [data-x] { color: blue; }")
+             )
+             |> Premailex.to_html() == ~s(<p class="a" data-x="1" style="color: blue;">Text</p>)
+
+      assert tree
+             |> HTMLInlineStyles.process(
+               CSSParser.parse("[data-x] { color: blue; } .a { color: red; }")
+             )
+             |> Premailex.to_html() == ~s(<p class="a" data-x="1" style="color: red;">Text</p>)
+    end
+
+    test "with higher specificity rule first takes precedence over source order" do
+      tree = Premailex.parse(~s(<p class="a b">Text</p>))
+
+      assert tree
+             |> HTMLInlineStyles.process(
+               CSSParser.parse("p.a { color: red; } .b { color: blue; }")
+             )
+             |> Premailex.to_html() == ~s(<p class="a b" style="color: red;">Text</p>)
+    end
+
     test "with wildcard rule" do
       tree =
         Premailex.parse("""


### PR DESCRIPTION
Fixes #110.

Declarations of equal specificity are again resolved by source order.

## Cause

`build_selector_items_lookup_table/1` buckets selector items by tag, id and class, and `applicable_selector_items/3` gathers matches one bucket at a time. Items are prepended within a bucket, and the buckets are concatenated in a fixed order, so the matches handed to the callback are in neither the given order nor any meaningful one.

`CSSParser.cascade/1` resolves ties by source order, taking the last, so the winner instead depended on which bucket a rule landed in and, for classes, on the order of the element's `class` attribute.

## Fix

Each selector item is tagged with its index when the table is built, and matches are sorted back into that order before the callback is called.

A selector item is registered once per selector group, so `.a, .b { … }` can match the same element twice. Those duplicates are consecutive after the sort and are now dropped.

## Tests

Five tests added to `html_inline_styles_test.exs`, covering source order for equal specificity rules, independence from `class` attribute order, duplicate selectors, and ties across selector types. Four of them fail on `main`. The fifth asserts that a higher specificity rule declared first still wins, which guards against over-correcting into plain last-one-wins.

Full parser matrix passes, along with `mix credo --strict`, `mix format --check-formatted`, `mix dialyzer` and `mix compile --warnings-as-errors`.

## Performance

`benchmark/to_inline_css.exs` with `HTML_PARSER=Xmerl`, times in ms:

| Case | main | this branch |
|---|---|---|
| common 150 nodes / 50 rules | 2.52 | 2.53 |
| common 500 / 200 | 8.29 | 7.96 |
| common 1500 / 500 | 24.64 | 23.17 |
| common 5000 / 1500 | 84.47 | 79.36 |
| wildcard 1000 nodes / 1 rule | 9.74 | 9.49 |
| wildcard 1000 / 20 | 25.86 | 27.00 |
| wildcard 5000 / 1 | 51.58 | 48.40 |
| wildcard 5000 / 20 | 134.80 | 127.23 |
| wildcard 10000 / 1 | 114.05 | 112.77 |
| wildcard 10000 / 20 | 252.42 | 264.32 |

Within run-to-run variance in both directions. The single match case, which is the common one, short circuits before sorting.
