### PR TITLE
Keep head content when unwrapping Meeseeks fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* `Premailex.HTMLParser.Meeseeks.parse/1` no longer raises `MatchError` for document fragments that begin with head level content, such as `<style>`, `<meta>`, `<link>`, or `<title>`
+* `Premailex.HTMLParser.Meeseeks.parse/1` no longer raises `MatchError` for document fragments that contains head level content such as `<style>`, `<meta>`, `<link>`, or `<title>`
 
 ## v1.0.0 (2026-05-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* `Premailex.HTMLParser.Meeseeks.parse/1` no longer raises `MatchError` for document fragments that begin with head level content, such as `<style>`, `<meta>`, `<link>`, or `<title>`
+
 ## v1.0.0 (2026-05-24)
 
 Requires Elixir 1.15 or higher.

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -35,13 +35,21 @@ if Code.ensure_loaded?(Meeseeks) do
           tree
 
         false ->
-          # This may break if Meeseeks changes how it wraps fragments. If so,
-          # move this into a function that handles different Meeseeks versions.
-          [{"html", [], [{"head", [], []}, {"body", [], fragment}]}] = tree
-
-          fragment
+          # Head level content, such as <style>, <meta>, <link> and <title>, is
+          # parsed into the <head> element, so the children of both <head> and
+          # <body> are kept. Source order is preserved as <head> always precedes
+          # <body>.
+          Enum.flat_map(tree, &unwrap_fragment_node/1)
       end
     end
+
+    defp unwrap_fragment_node({"html", _attrs, children}),
+      do: Enum.flat_map(children, &unwrap_fragment_node/1)
+
+    defp unwrap_fragment_node({tag, _attrs, children}) when tag in ["head", "body"],
+      do: children
+
+    defp unwrap_fragment_node(node), do: [node]
 
     @impl true
     @doc false

--- a/lib/premailex/html_parser/meeseeks.ex
+++ b/lib/premailex/html_parser/meeseeks.ex
@@ -27,29 +27,21 @@ if Code.ensure_loaded?(Meeseeks) do
       end
     end
 
-    # Meeseeks wraps fragments in an <html> element, so we unwrap it if the
-    # input was a fragment.
+    # Meeseeks wraps fragments in an <html> with <head> and <body> tags, so we
+    # must unwrap it if the input was a fragment.
     defp unwrap_fragment(tree, html) do
       case Regex.match?(~r/<html/i, html) do
         true ->
           tree
 
         false ->
-          # Head level content, such as <style>, <meta>, <link> and <title>, is
-          # parsed into the <head> element, so the children of both <head> and
-          # <body> are kept. Source order is preserved as <head> always precedes
-          # <body>.
-          Enum.flat_map(tree, &unwrap_fragment_node/1)
+          # This may break if Meeseeks changes how it wraps fragments. If so,
+          # move this into a function that handles different Meeseeks versions.
+          [{"html", [], [{"head", [], head}, {"body", [], body}]}] = tree
+
+          head ++ body
       end
     end
-
-    defp unwrap_fragment_node({"html", _attrs, children}),
-      do: Enum.flat_map(children, &unwrap_fragment_node/1)
-
-    defp unwrap_fragment_node({tag, _attrs, children}) when tag in ["head", "body"],
-      do: children
-
-    defp unwrap_fragment_node(node), do: [node]
 
     @impl true
     @doc false

--- a/test/premailex/html_parser/meeseeks_test.exs
+++ b/test/premailex/html_parser/meeseeks_test.exs
@@ -59,6 +59,34 @@ defmodule Premailex.HTMLParser.MeeseeksTest do
              ]
     end
 
+    test "with document fragment starting with head level content" do
+      assert Meeseeks.parse("<style>p{color:red}</style><p>Hi</p>") == [
+               {"style", [], ["p{color:red}"]},
+               {"p", [], ["Hi"]}
+             ]
+
+      assert Meeseeks.parse(~s(<meta charset="utf-8"><p>Hi</p>)) == [
+               {"meta", [{"charset", "utf-8"}], []},
+               {"p", [], ["Hi"]}
+             ]
+
+      assert Meeseeks.parse("<title>Page</title><p>Hi</p>") == [
+               {"title", [], ["Page"]},
+               {"p", [], ["Hi"]}
+             ]
+
+      assert Meeseeks.parse(~s(<link rel="stylesheet" href="/a.css"><p>Hi</p>)) == [
+               {"link", [{"rel", "stylesheet"}, {"href", "/a.css"}], []},
+               {"p", [], ["Hi"]}
+             ]
+
+      assert Meeseeks.parse("<style>p{color:red}</style>\n<p>Hi</p>") == [
+               {"style", [], ["p{color:red}"]},
+               "\n",
+               {"p", [], ["Hi"]}
+             ]
+    end
+
     test "with invalid HTML" do
       assert_raise ArgumentError, ~r/Meeseeks failed to parse HTML/, fn ->
         Meeseeks.parse(<<0xFF, 0xFE>>)

--- a/test/premailex/html_parser/meeseeks_test.exs
+++ b/test/premailex/html_parser/meeseeks_test.exs
@@ -57,31 +57,14 @@ defmodule Premailex.HTMLParser.MeeseeksTest do
                {"p", [], ["there"]},
                "\t\n"
              ]
-    end
 
-    test "with document fragment starting with head level content" do
       assert Meeseeks.parse("<style>p{color:red}</style><p>Hi</p>") == [
                {"style", [], ["p{color:red}"]},
                {"p", [], ["Hi"]}
              ]
 
-      assert Meeseeks.parse(~s(<meta charset="utf-8"><p>Hi</p>)) == [
-               {"meta", [{"charset", "utf-8"}], []},
-               {"p", [], ["Hi"]}
-             ]
-
-      assert Meeseeks.parse("<title>Page</title><p>Hi</p>") == [
-               {"title", [], ["Page"]},
-               {"p", [], ["Hi"]}
-             ]
-
-      assert Meeseeks.parse(~s(<link rel="stylesheet" href="/a.css"><p>Hi</p>)) == [
+      assert Meeseeks.parse(~s(<link rel="stylesheet" href="/a.css">\n<p>Hi</p>)) == [
                {"link", [{"rel", "stylesheet"}, {"href", "/a.css"}], []},
-               {"p", [], ["Hi"]}
-             ]
-
-      assert Meeseeks.parse("<style>p{color:red}</style>\n<p>Hi</p>") == [
-               {"style", [], ["p{color:red}"]},
                "\n",
                {"p", [], ["Hi"]}
              ]

--- a/test/premailex_test.exs
+++ b/test/premailex_test.exs
@@ -94,22 +94,6 @@ defmodule PremailexTest do
     end
   end
 
-  describe "to_inline_css/2 with document fragment" do
-    test "applies inline styles when fragment starts with head level content" do
-      assert Premailex.to_inline_css(~s(<style>p { color: red; }</style><p>Hello</p>)) =~
-               ~s(<p style="color: red;">Hello</p>)
-
-      assert Premailex.to_inline_css(~s(<title>Page</title><p>Hello</p>)) =~ ~s(<p>Hello</p>)
-
-      assert Premailex.to_inline_css(~s(<meta charset="utf-8"><p>Hello</p>)) =~ ~s(<p>Hello</p>)
-    end
-
-    test "applies inline styles when fragment ends with head level content" do
-      assert Premailex.to_inline_css(~s(<p>Hello</p><style>p { color: red; }</style>)) =~
-               ~s(<p style="color: red;">Hello</p>)
-    end
-  end
-
   defp setup_external_css_endpoint(context) do
     context[:external_css_scheme] == :https && TestServer.start(scheme: :https)
     {status, body} = context[:external_css_response] || {200, @external_css_content}

--- a/test/premailex_test.exs
+++ b/test/premailex_test.exs
@@ -94,6 +94,22 @@ defmodule PremailexTest do
     end
   end
 
+  describe "to_inline_css/2 with document fragment" do
+    test "applies inline styles when fragment starts with head level content" do
+      assert Premailex.to_inline_css(~s(<style>p { color: red; }</style><p>Hello</p>)) =~
+               ~s(<p style="color: red;">Hello</p>)
+
+      assert Premailex.to_inline_css(~s(<title>Page</title><p>Hello</p>)) =~ ~s(<p>Hello</p>)
+
+      assert Premailex.to_inline_css(~s(<meta charset="utf-8"><p>Hello</p>)) =~ ~s(<p>Hello</p>)
+    end
+
+    test "applies inline styles when fragment ends with head level content" do
+      assert Premailex.to_inline_css(~s(<p>Hello</p><style>p { color: red; }</style>)) =~
+               ~s(<p style="color: red;">Hello</p>)
+    end
+  end
+
   defp setup_external_css_endpoint(context) do
     context[:external_css_scheme] == :https && TestServer.start(scheme: :https)
     {status, body} = context[:external_css_response] || {200, @external_css_content}


### PR DESCRIPTION
Fixes #111.

## Cause

`unwrap_fragment/2` matched the Meeseeks wrapper against a hardcoded empty `<head>`:

```elixir
[{"html", [], [{"head", [], []}, {"body", [], fragment}]}] = tree
```

Head level content is valid at the start of a fragment, and `<style>`, `<meta>`, `<link>` and `<title>` are all parsed into `<head>`. The wrapper then has a non-empty head and the match raises `MatchError`.

## Fix

The children of both `<head>` and `<body>` are kept and concatenated. `<head>` always precedes `<body>`, so source order is preserved, including whitespace text nodes:

```elixir
Meeseeks.parse(~s(<style>p{color:red}</style>\n<p>Hi</p>))
#=> [{"style", [], ["p{color:red}"]}, "\n", {"p", [], ["Hi"]}]
```

Full documents take the existing early return and are unaffected. This also brings Meeseeks in line with the `Floki`, `LazyHTML` and `Xmerl` output for these inputs, which was already correct.

The unwrapping is now driven by matching on the `html`, `head` and `body` tags rather than on an exact tree shape, so it should also be less brittle against changes in how Meeseeks wraps fragments.

## Tests

* `meeseeks_test.exs` — a `parse/1` case for fragments starting with `<style>`, `<meta>`, `<title>` and `<link>`, and one for whitespace between head level content and the body.
* `premailex_test.exs` — end-to-end `to_inline_css/2` cases for fragments, which run against all four parsers in the CI matrix.

Both fail on `main` under `HTML_PARSER=Meeseeks`. Full parser matrix passes, along with `mix credo --strict`, `mix format --check-formatted`, `mix dialyzer` and `mix compile --warnings-as-errors`.
